### PR TITLE
Fix - Binary Watch Draw Optimisation and Refactor.

### DIFF
--- a/Platform-io-source/src/tw_faces/face_Watch_CustomBinary.cpp
+++ b/Platform-io-source/src/tw_faces/face_Watch_CustomBinary.cpp
@@ -1,29 +1,18 @@
 #include "tw_faces/face_Watch_CustomBinary.h"
 #include "fonts/Clock_Digits.h"
-//#include "fonts/RobotoMono_Light_All.h"
 #include "fonts/RobotoMono_Regular_All.h"
-//#include "fonts/Roboto_Regular18.h"
 #include "bitmaps/bitmaps_general.h"
 #include "peripherals/battery.h"
 #include "peripherals/imu.h"
 #include "settings/settings.h"
 #include "tinywatch.h"
-#include <bitset>
 
 void FaceWatch_CustomBinary::setup()
 {
 	if (!is_setup)
 	{
 		is_setup = true;
-		// Add any one time setup code here
 	}
-}
-
-// Easier to read than using a binary shift.
-bool is_onoff(int number, int position) 
-{
-    std::bitset<6> binaryRepresentation(number);
-    return binaryRepresentation.test(position);
 }
 
 void FaceWatch_CustomBinary::draw(bool force)
@@ -46,15 +35,18 @@ void FaceWatch_CustomBinary::draw(bool force)
 			uint8_t secs = rtc.get_seconds();
 
 			// Only fetch the mins, hrs, and date once a minute. 
-			// Also do it for first run (year cant be 0)
-			if (secs == 0 || year == 0) 
+			// Also do it for first run (year cant be 0, or 2000)
+			if (secs == 0 || year == 0 || year == 2000) 
 			{
 				mins = rtc.get_mins();
 				hours = rtc.get_hours();
 				day = rtc.get_day();
 				month = rtc.get_month();
 				year = rtc.get_year();
-				tinywatch.log_system_message("Fetching T/D");
+
+				// Offset the Date for single/multiple digits
+				if (day > 9 )
+					day_offset = 0;
 			}
 			
 			uint8_t posmul = 32;
@@ -69,7 +61,7 @@ void FaceWatch_CustomBinary::draw(bool force)
 			// Set Colours
 			int16_t on_color = on_colors[settings.config.custom_binary.binary_clockcolour]; 
 			int16_t off_color = off_colors[settings.config.custom_binary.binary_clockcolour]; 
-			int16_t bdr_color = RGB(0x12, 0x12, 0x12);
+			int16_t bdr_color = RGB(0x0A, 0x0A, 0x0A);
 			int16_t tim_color = RGB(0xff, 0xff, 0xff);
 			int8_t clock_style = settings.config.custom_binary.binary_clockstyle;
 				
@@ -77,30 +69,35 @@ void FaceWatch_CustomBinary::draw(bool force)
 			int box_counts[6] = {4, 3, 4, 3, 4, 2};      // Not all columns need 4 boxes
 			int digit_num[6] = {secs % 10, secs / 10, mins % 10, mins / 10, hours % 10, hours / 10}; // this returns the individual digit for each column
 
+			int half_posmul = posmul/2;
+
 			for (int digit = 0; digit < 6; ++digit) 
 			{
 				int xOffset = x_offset + (posmul * box_positions[digit]) + (x_space * box_positions[digit]);
 				for (int box_y = 0; box_y < box_counts[digit]; ++box_y) {
-					if (is_onoff(digit_num[digit], box_y))
+					//if (is_onoff(, ))
+					if ((digit_num[digit] & (1 << box_y)) != 0)
 						if (clock_style == 0) 
 							canvas[canvasid].fillRect(xOffset, y_offset - (box_y * (posmul + y_space)), posmul, posmul, on_color);
 
 						else
-							canvas[canvasid].fillSmoothCircle(xOffset + (posmul/2), y_offset - (box_y * (posmul + y_space)) + (posmul/2), posmul/2, on_color);
+							canvas[canvasid].fillSmoothCircle(xOffset + (half_posmul), y_offset - (box_y * (posmul + y_space)) + (half_posmul), half_posmul, on_color);
 
 					else
 						if (clock_style == 0) 
 							canvas[canvasid].fillRect(xOffset, y_offset - (box_y * (posmul + y_space)), posmul, posmul, off_color);
 
 						else
-							canvas[canvasid].fillSmoothCircle(xOffset + (posmul/2), y_offset - (box_y * (posmul + y_space)) + (posmul/2), posmul/2, off_color);
+							canvas[canvasid].fillSmoothCircle(xOffset + (half_posmul), y_offset - (box_y * (posmul + y_space)) + (half_posmul), half_posmul, off_color);
+					if (show_borders)
+					{
+						if (clock_style == 0) 
+							canvas[canvasid].drawRect(xOffset, y_offset - (box_y * (posmul + y_space)), posmul, posmul, bdr_color);
 
-					if (clock_style == 0) 
-						canvas[canvasid].drawRect(xOffset, y_offset - (box_y * (posmul + y_space)), posmul, posmul, bdr_color);
+						else
+					 		canvas[canvasid].drawCircle(xOffset + (half_posmul), y_offset - (box_y * (posmul + y_space)) + (half_posmul), half_posmul, bdr_color);
 
-					else
-						canvas[canvasid].drawCircle(xOffset + (posmul/2), y_offset - (box_y * (posmul + y_space)) + (posmul/2), posmul/2, bdr_color);
-
+					}
 				}
 			}
 
@@ -108,7 +105,7 @@ void FaceWatch_CustomBinary::draw(bool force)
 			int16_t digit_backcolor[6] = {off_color, off_color, off_color, off_color, off_color, off_color};
 			for (int i = 0; i < 6; ++i) 
 			{
-				if (is_onoff(digit_num[i], 0))
+				if ((digit_num[i] & (1 << 0)) != 0)
 				digit_backcolor[i] = on_color;
 			}
 
@@ -121,12 +118,6 @@ void FaceWatch_CustomBinary::draw(bool force)
 				y_offset - (0 * (posmul + y_space)) + digit_yoffset);
 			}
 
-			
-			// Offset the Date for single/multiple digits
-			int8_t day_offset = -16;
-			if (day > 9 )
-				day_offset = 0;
-			
 			// Show date below the clock
 			canvas[canvasid].setFreeFont(Clock_Digit_7SEG[2]);
 			canvas[canvasid].setTextColor(tim_color, RGB(0x00, 0x00, 0x00));				
@@ -149,7 +140,7 @@ bool FaceWatch_CustomBinary::click(uint pos_x, uint pos_y)
 {
 	// Cycle through the colour pallette, after one full cycle, switch the style (square/circle)
 	settings.config.custom_binary.binary_clockcolour++;
-	if (settings.config.custom_binary.binary_clockcolour > 8) 
+	if (settings.config.custom_binary.binary_clockcolour >= 3) 
 	{ 
 		settings.config.custom_binary.binary_clockstyle = !(settings.config.custom_binary.binary_clockstyle);
 		settings.config.custom_binary.binary_clockcolour = 0;

--- a/Platform-io-source/src/tw_faces/face_Watch_CustomBinary.h
+++ b/Platform-io-source/src/tw_faces/face_Watch_CustomBinary.h
@@ -15,31 +15,19 @@ class FaceWatch_CustomBinary : public tw_face
         String version = "1.0";
 
 		// Binary Watch Colour Pallette - On
-		const uint16_t on_colors[9] = 
+		const uint16_t on_colors[3] = 
 		{
 			RGB(127, 0, 0),
-			RGB(127, 63, 0),
-			RGB(127, 127, 0),
-			RGB(127, 255, 0),
-			RGB(0, 255, 0),
-			RGB(0, 255, 128),
-			RGB(0, 255, 255),
-			RGB(0, 128, 255),
-			RGB(0, 0, 255),
+			RGB(0, 127, 0),
+			RGB(0, 0, 191),
 		};
 
 		// Binary Watch Colour Pallette - Off
-		const uint16_t off_colors[9] = 
+		const uint16_t off_colors[3] = 
 		{
 			RGB(32, 0, 0),
-			RGB(32, 24, 0),
-			RGB(32, 48, 0),
-			RGB(24, 48, 0),
-			RGB(0, 48, 0),
-			RGB(0, 48, 24),
-			RGB(0, 48, 48),
-			RGB(0, 24, 48),
-			RGB(0, 0, 48),
+			RGB(0, 32, 0),
+			RGB(0, 0, 32),
 		};
 
 		const String months[12] = 
@@ -49,7 +37,9 @@ class FaceWatch_CustomBinary : public tw_face
 			"JUL", "AUG", "SEP",
 			"OCT", "NOV", "DEC"
 		};
-			
+		
+		// Settings
+		bool show_borders = true;
 
 		// Kept for Caching
 		uint8_t hours = 0;
@@ -57,7 +47,7 @@ class FaceWatch_CustomBinary : public tw_face
 		uint16_t day = 0;
 		uint16_t month = 0;
 		uint16_t year = 0;
-
+		int8_t day_offset = -16;
 
 };
 


### PR DESCRIPTION
- Simplified the colour palette (now three colour choices and option of square/circle)
- Fixed cold start time display (now polls the RTC every time it refreshes if the date/time is unset
- Time is now polled only once a minute, seconds sill polled each refresh
- Day offset check now only occurs once a minute
- Borders can be switched on and off in code (not switchable at runtime yet) (Settings display?)