### PR TITLE
Fix: App Icon Spacing, Add Example App

### DIFF
--- a/Platform-io-source/src/display.cpp
+++ b/Platform-io-source/src/display.cpp
@@ -47,6 +47,7 @@ Display display;
 #include "tw_apps/app_Compass.h"
 #include "tw_apps/app_Microphone.h"
 #include "tw_apps/tw_app.h"
+#include "tw_apps/app_Empty.h"
 
 // Other
 #include "bitmaps/bitmaps_general.h"
@@ -286,16 +287,20 @@ void Display::createFaces(bool was_sleeping)
 	if (was_sleeping)
 		show_watch_from_boot();
 
-	face_imu.add("IMU", 100, 80);
-	// face_compass.add("Compass", 100, 80);
-
+	// Create Applications
 	app_microphone.add("FFT", 25, 160);
 	app_compass.add("Compass", 100, 80);
+	app_empty.add("Empty", 1000, 40);
 
+	// Create Applications Face
 	face_applist.add("APPS", 1000, 40);
 	face_applist.set_single_navigation(LEFT, current_clock_face);
 	face_applist.add_app(&app_microphone);
 	face_applist.add_app(&app_compass);
+	face_applist.add_app(&app_empty);
+
+	// Create Faces
+	face_imu.add("IMU", 100, 80);
 
 	face_notifications.add("Messages", 1000, 80);
 	face_notifications.set_scrollable(false, true);

--- a/Platform-io-source/src/tw_apps/app_Empty.cpp
+++ b/Platform-io-source/src/tw_apps/app_Empty.cpp
@@ -1,0 +1,120 @@
+
+#include "tw_apps/app_Empty.h"
+// #include "fonts/RobotoMono_Light_All.h"
+#include "fonts/RobotoMono_Regular_All.h"
+
+/**
+ * @brief Called the first time an app is opened
+ *
+ * Put any one off setup code in here
+ *
+ */
+void AppEmpty::setup()
+{
+	if (!is_setup)
+	{
+		is_setup = true;
+	}
+}
+
+/**
+ * @brief Put anything in here that you want to have run every time the app is opened
+ *
+ * This is not the same as setup() above that only ever gets called the first time the app opens
+ *
+ */
+void AppEmpty::pre_start() { shutdown_timer = millis(); }
+
+/**
+ * @brief Draw the icon that gets shown on the app menu face
+ *
+ * Icons are 64x64 with rounded corners as per the code below, but the inner content can be anything that represents the app well
+ * @param canvasid
+ * @param _pos_x
+ * @param _pos_y
+ * @param style_hint
+ */
+void AppEmpty::draw_icon(uint8_t canvasid, int16_t _pos_x, int16_t _pos_y, uint8_t style_hint)
+{
+	if (!is_icon_cached)
+	{
+		is_icon_cached = true;
+		icon_sprite.fillSprite(0);
+		icon_sprite.drawSmoothRoundRect(0, 0, 10, 6, icon_width, icon_width, RGB(0xCC, 0xAA, 0x77), 0);
+		icon_sprite.setTextDatum(4); // Middle, Center
+		icon_sprite.setFreeFont(RobotoMono_Regular[15]);
+		icon_sprite.setTextColor(TFT_WHITE);
+		icon_sprite.drawString("Hi", icon_width / 2, icon_width / 2);
+	}
+
+	icon_x = _pos_x;
+	icon_y = _pos_y;
+	icon_sprite.pushToSprite(&canvas[canvasid], _pos_x, _pos_y);
+}
+
+/**
+ * @brief Usual draw code that draws the apps content, like a face draw it's content
+ *
+ * @param force
+ */
+void AppEmpty::draw(bool force)
+{
+	// Override the CPU settings for this app (if needed)
+	// setCpuFrequencyMhz(160);
+
+	setup();
+
+	// Example of how to auto shut down the app after a period of time
+	//
+	// if (millis() - shutdown_timer > 5000)
+	// {
+	// 	// close without saving settings
+	// 	close(false);
+	// 	return;
+	// }
+
+	if (force || millis() - next_update > update_period)
+	{
+		next_update = millis();
+
+		canvas[canvasid].fillSprite(TFT_BLACK);
+
+		// Start Custom App Code
+
+		canvas[canvasid].fillSprite(TFT_BLACK);
+		canvas[canvasid].setTextDatum(MC_DATUM); // Middle, Center
+		canvas[canvasid].setFreeFont(RobotoMono_Regular[15]);
+		canvas[canvasid].setTextColor(TFT_GREEN);
+		canvas[canvasid].drawString("Hello, World", display.center_x, display.center_y);
+
+		// End Custom App Code
+	}
+	canvas[canvasid].pushSprite(_x, _y);
+}
+
+/**
+ * @brief Did we click on the app? If so, where?
+ *
+ * @param click_pos_x
+ * @param click_pos_y
+ * @return true
+ * @return false
+ */
+bool AppEmpty::click(uint16_t click_pos_x, uint16_t click_pos_y)
+{
+
+	return false;
+}
+
+/**
+ * @brief Did we double click on the app? If so, where?
+ *
+ * @param click_pos_x
+ * @param click_pos_y
+ * @return true
+ * @return false
+ */
+
+bool AppEmpty::click_double(uint16_t click_pos_x, uint16_t click_pos_y) { return false; }
+
+AppEmpty app_empty;

--- a/Platform-io-source/src/tw_apps/app_Empty.h
+++ b/Platform-io-source/src/tw_apps/app_Empty.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "tw_apps/tw_app.h"
+
+class AppEmpty : public tw_app
+{
+	public:
+		// virtual methods
+		void setup(void);
+		void pre_start(void);
+		void draw(bool force);
+		void draw_icon(uint8_t canvasid, int16_t _pos_x, int16_t _pos_y, uint8_t style_hint);
+		bool click(uint16_t click_pos_x, uint16_t click_pos_y);
+		bool click_double(uint16_t click_pos_x, uint16_t click_pos_y);
+
+		// local methods
+		
+	private:
+		unsigned long shutdown_timer = 0;
+};
+
+extern AppEmpty app_empty;

--- a/Platform-io-source/src/tw_faces/face_AppList.cpp
+++ b/Platform-io-source/src/tw_faces/face_AppList.cpp
@@ -89,17 +89,19 @@ void FaceAppList::draw(bool force)
 			canvas[canvasid].setFreeFont(RobotoMono_Regular[15]);
 			canvas[canvasid].setTextColor(TFT_GREEN);
 
-			int16_t icon_x = 20;
-			int16_t icon_y = 20;
+			int8_t icon_spacing = 9;
+
+			int16_t icon_x = icon_spacing;
+			int16_t icon_y = icon_spacing;
 
 			for (auto _app : app_icons)
 			{
 				_app.second->draw_icon(canvasid, icon_x, icon_y, 0);
-				icon_x += 84;
-				if (icon_x > 262)
+				icon_x += 64 + icon_spacing;
+				if (icon_x > ((64 + icon_spacing) * 3))
 				{
-					icon_x = 84;
-					icon_y += 84;
+					icon_x = icon_spacing;
+					icon_y += 64 + icon_spacing;
 				}
 			}
 		}

--- a/Platform-io-source/src/tw_faces/face_Empty.cpp
+++ b/Platform-io-source/src/tw_faces/face_Empty.cpp
@@ -26,10 +26,15 @@ void FaceEmpty::draw(bool force)
 			if (is_dragging)
 				is_cached = true;
 
+			// Start Custom Face Code
+
 			canvas[canvasid].fillSprite(TFT_BLACK);
-			canvas[canvasid].setTextDatum(4); // Middle, Center
+			canvas[canvasid].setTextDatum(MC_DATUM); // Middle, Center
 			canvas[canvasid].setFreeFont(RobotoMono_Regular[15]);
 			canvas[canvasid].setTextColor(TFT_GREEN);
+			canvas[canvasid].drawString("Hello, World", display.center_x, display.center_y);
+
+			// End Custom Face Code
 		}
 
 		canvas[canvasid].pushSprite(_x, _y);


### PR DESCRIPTION
* Updated App Icon Spacing for consistency
* Updated App Icon Newline Wrapping (left justify for now)
* Added Example (Empty) Application
* Updated Example Face to match Example Application
* Re-ordered App/Face loading in display.cpp for readability
* Misc. commenting