### PR TITLE
Add: Windows Clock Face

### DIFF
--- a/Platform-io-source/src/display.cpp
+++ b/Platform-io-source/src/display.cpp
@@ -354,6 +354,11 @@ void Display::createFaces(bool was_sleeping)
 	cToggle5->create("Alarm", "OFF", "ON", 130, 210, 80, 30);
 	cToggle5->set_data(&settings.setting_audio_alarm);
 
+	ControlToggle *cToggle6 = new ControlToggle();
+	cToggle6->create("Date Format", "DMY", "MDY", 130, 130, 80, 30);
+	cToggle6->set_data(&settings.setting_time_dateformat);
+
+
 	// ControlButton * cButton1 = new ControlButton();
 	// cButton1->create("SAVE", 70, 250, 100, 40);
 	// cButton1->set_callback(force_save);
@@ -371,6 +376,7 @@ void Display::createFaces(bool was_sleeping)
 	face_settings.add_control(cLabel1);
 	face_settings.add_control(cToggle4);
 	face_settings.add_control(cToggle5);
+	face_settings.add_control(cToggle6);
 	// face_settings.add_control(cValue1);
 	// face_settings.add_control(cValue2);
 }

--- a/Platform-io-source/src/display.cpp
+++ b/Platform-io-source/src/display.cpp
@@ -17,6 +17,7 @@ Display display;
 
 // Custom Faces
 #include "tw_faces/face_Watch_CustomBinary.h"
+#include "tw_faces/face_Watch_CustomWindows.h"
 
 // Faces General
 #include "tw_faces/face_AppList.h"
@@ -271,6 +272,11 @@ void Display::createFaces(bool was_sleeping)
 	face_watch_custom_binary.add_widget(wBattery);
 	face_watch_custom_binary.add_widget(wActivity);
 	face_watch_custom_binary.add_widget(wWifi);
+
+	face_watch_custom_windows.add_clock("Clock_Custom_Windows", 1000);
+	//face_watch_custom_windows.add_widget(wBattery);
+	//face_watch_custom_windows.add_widget(wActivity);
+	//face_watch_custom_windows.add_widget(wWifi);
 
 	// needs a default clock face so it won't crash
 	// all clock faces need to be initialised before this

--- a/Platform-io-source/src/settings/settings.cpp
+++ b/Platform-io-source/src/settings/settings.cpp
@@ -18,7 +18,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Config_open_weather, api_key, po
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Config_custom_binary, binary_clockcolour, binary_clockstyle);
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Config, wifi_start, wifi_ssid, wifi_pass, mdns_name, website_darkmode, mqtt, battery, open_weather, city, country, utc_offset, bl_period_vbus, bl_period_vbat, time_24hour, clock_face_index, left_handed, flipped, audio_ui, audio_alarm, imu_process_steps, imu_process_wrist);
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Config, wifi_start, wifi_ssid, wifi_pass, mdns_name, website_darkmode, mqtt, battery, open_weather, city, country, utc_offset, bl_period_vbus, bl_period_vbat, time_24hour, time_dateformat,clock_face_index, left_handed, flipped, audio_ui, audio_alarm, imu_process_steps, imu_process_wrist);
 
 void Settings::log_to_nvs(const char *key, const char *log)
 {

--- a/Platform-io-source/src/settings/settings.h
+++ b/Platform-io-source/src/settings/settings.h
@@ -44,6 +44,7 @@ struct Config
 
 		// Time
 		bool time_24hour = false;
+		bool time_dateformat = false;	// False - DMY, True - MDY
 		uint8_t clock_face_index = 0;
 
 		// Watch
@@ -80,6 +81,7 @@ class Settings
 		// Add any SettingsOption values here for any settings you want to bind with a tw_Control
 		SettingsOptionBool setting_wifi_start{&config.wifi_start};
 		SettingsOptionBool setting_time_24hour{&config.time_24hour};
+		SettingsOptionBool setting_time_dateformat{&config.time_dateformat};
 		SettingsOptionBool setting_left_handed{&config.left_handed};
 		SettingsOptionBool setting_flipped{&config.flipped};
 		SettingsOptionBool setting_audio_ui{&config.audio_ui};

--- a/Platform-io-source/src/tw_faces/face_Watch_CustomWindows.cpp
+++ b/Platform-io-source/src/tw_faces/face_Watch_CustomWindows.cpp
@@ -23,17 +23,42 @@ void FaceWatch_CustomWindows::setup_trig()
 
 	for (int tick = 0; tick < 60; tick++)
 	{
-		if (tick % 5 == 0)
-		{
-			pos_hours[b][0] = ((face_radius - 60) * cos(i)) + center_x;
-			pos_hours[b][1] = ((face_radius - 60) * sin(i)) + center_y;
-			b++;
-		}
+		pos_hours[tick][0] = ((face_radius - 50) * cos(i)) + center_x;
+		pos_hours[tick][1] = ((face_radius - 50) * sin(i)) + center_y;
 
 		pos_mins[tick][0] = ((face_radius - 30) * cos(i)) + center_x;
 		pos_mins[tick][1] = ((face_radius - 30) * sin(i)) + center_y;
+
 		pos_secs[tick][0] = ((face_radius - 20) * cos(i)) + center_x;
 		pos_secs[tick][1] = ((face_radius - 20) * sin(i)) + center_y;
+
+		// Generate offsets for fancy hr/min hand
+		int tick_lo = tick + 15;
+		if (tick > 45)
+			tick_lo = tick - 45;
+
+		int tick_ro = tick + 45;
+		if (tick > 15)
+			tick_ro = tick - 15;
+
+		int tick_rear = tick + 30;
+		if (tick > 30)
+			tick_rear = tick - 30;
+
+		pos_lo[tick_lo][0] = (4 * cos(i)) + center_x;
+		pos_lo[tick_lo][1] = (4 * sin(i)) + center_y;
+		pos_ro[tick_ro][0] = (4 * cos(i)) + center_x;
+		pos_ro[tick_ro][1] = (4 * sin(i)) + center_y;
+
+		pos_mins_rlo[tick_rear][0] = (16 * cos(i)) + center_x;
+		pos_mins_rlo[tick_rear][1] = (16 * sin(i)) + center_y;
+		pos_mins_rro[tick_rear][0] = (16 * cos(i)) + center_x;
+		pos_mins_rro[tick_rear][1] = (16 * sin(i)) + center_y;
+
+		pos_hours_rlo[tick_rear][0] = (10 * cos(i)) + center_x;
+		pos_hours_rlo[tick_rear][1] = (10 * sin(i)) + center_y;
+		pos_hours_rro[tick_rear][0] = (10 * cos(i)) + center_x;
+		pos_hours_rro[tick_rear][1] = (10 * sin(i)) + center_y;
 
 		i += M_PI * 2.0 / 60.0;
 	}
@@ -147,17 +172,33 @@ void FaceWatch_CustomWindows::draw(bool force)
 			// Hours Dots
 			for (int x = 0; x < 12; x++)
 			{
-				canvas[canvasid].fillRect(pos_secs[x*5][0] - 1, pos_secs[x*5][1] - 1, 5, 5, winclock.color_buttonshadow);
-				canvas[canvasid].fillRect(pos_secs[x*5][0] - 2, pos_secs[x*5][1] - 2, 5, 5, winclock.color_hourblock);
+				canvas[canvasid].fillRect(pos_secs[x * 5][0] - 1, pos_secs[x * 5][1] - 1, 5, 5, winclock.color_buttonshadow);
+				canvas[canvasid].fillRect(pos_secs[x * 5][0] - 2, pos_secs[x * 5][1] - 2, 5, 5, winclock.color_hourblock);
 			}
 
 			// Analog Clock Hands
 			if (hours > 12)
 				hours -= 12;
 
-			canvas[canvasid].drawWideLine(center_x, center_y, pos_hours[hours][0], pos_hours[hours][1], 4.0f, winclock.color_hrminhand);
-			canvas[canvasid].drawWideLine(center_x, center_y, pos_mins[mins][0], pos_mins[mins][1], 4.0f, winclock.color_hrminhand);
+			// Move the hours hand with the precision of minutes
+			int hr_index = (hours * 5) + (mins / 5);
+
+			// Seconds Hand
 			canvas[canvasid].drawWideLine(center_x, center_y, pos_secs[secs][0], pos_secs[secs][1], 1.0f, winclock.color_sechand);
+
+			// Minutes Hand
+			canvas[canvasid].drawWideLine(pos_lo[mins][0], pos_lo[mins][1], pos_mins[mins][0], pos_mins[mins][1], 1.0f, winclock.color_hrminhand);
+			canvas[canvasid].drawWideLine(pos_ro[mins][0], pos_ro[mins][1], pos_mins[mins][0], pos_mins[mins][1], 1.0f, winclock.color_hrminhand);
+			// Mins Hand Rear
+			canvas[canvasid].drawWideLine(pos_lo[mins][0], pos_lo[mins][1], pos_mins_rlo[mins][0], pos_mins_rlo[mins][1], 1.0f, winclock.color_hrminhand);
+			canvas[canvasid].drawWideLine(pos_ro[mins][0], pos_ro[mins][1], pos_mins_rro[mins][0], pos_mins_rro[mins][1], 1.0f, winclock.color_hrminhand);
+
+			// Hours Hand
+			canvas[canvasid].drawWideLine(pos_lo[hr_index][0], pos_lo[hr_index][1], pos_hours[hr_index][0], pos_hours[hr_index][1], 1.0f, winclock.color_hrminhand);
+			canvas[canvasid].drawWideLine(pos_ro[hr_index][0], pos_ro[hr_index][1], pos_hours[hr_index][0], pos_hours[hr_index][1], 1.0f, winclock.color_hrminhand);
+			// Hours Hand Rear
+			canvas[canvasid].drawWideLine(pos_lo[hr_index][0], pos_lo[hr_index][1], pos_hours_rlo[hr_index][0], pos_hours_rlo[hr_index][1], 1.0f, winclock.color_hrminhand);
+			canvas[canvasid].drawWideLine(pos_ro[hr_index][0], pos_ro[hr_index][1], pos_hours_rro[hr_index][0], pos_hours_rro[hr_index][1], 1.0f, winclock.color_hrminhand);
 
 			// Clock Face Ends Here
 

--- a/Platform-io-source/src/tw_faces/face_Watch_CustomWindows.cpp
+++ b/Platform-io-source/src/tw_faces/face_Watch_CustomWindows.cpp
@@ -182,6 +182,8 @@ void FaceWatch_CustomWindows::draw(bool force)
 
 			// Move the hours hand with the precision of minutes
 			int hr_index = (hours * 5) + (mins / 12);
+			if (hr_index > 59)
+				hr_index -= 60;
 
 			// Seconds Hand
 			canvas[canvasid].drawWideLine(center_x, center_y, pos_secs[secs][0], pos_secs[secs][1], 1.0f, winclock.color_sechand);
@@ -199,6 +201,9 @@ void FaceWatch_CustomWindows::draw(bool force)
 			// Hours Hand Rear
 			canvas[canvasid].drawWideLine(pos_lo[hr_index][0], pos_lo[hr_index][1], pos_hours_rlo[hr_index][0], pos_hours_rlo[hr_index][1], 1.0f, winclock.color_hrminhand);
 			canvas[canvasid].drawWideLine(pos_ro[hr_index][0], pos_ro[hr_index][1], pos_hours_rro[hr_index][0], pos_hours_rro[hr_index][1], 1.0f, winclock.color_hrminhand);
+
+			// Hour Debug
+			info_println("Index: " + String(hr_index) + ", index0: " + String(pos_hours[hr_index][0]) + ", index1: " + String(pos_hours[hr_index][1]));
 
 			// Clock Face Ends Here
 

--- a/Platform-io-source/src/tw_faces/face_Watch_CustomWindows.cpp
+++ b/Platform-io-source/src/tw_faces/face_Watch_CustomWindows.cpp
@@ -34,15 +34,15 @@ void FaceWatch_CustomWindows::setup_trig()
 
 		// Generate offsets for fancy hr/min hand
 		int tick_lo = tick + 15;
-		if (tick > 45)
+		if (tick >= 45)
 			tick_lo = tick - 45;
 
 		int tick_ro = tick + 45;
-		if (tick > 15)
+		if (tick >= 15)
 			tick_ro = tick - 15;
 
 		int tick_rear = tick + 30;
-		if (tick > 30)
+		if (tick >= 30)
 			tick_rear = tick - 30;
 
 		pos_lo[tick_lo][0] = (4 * cos(i)) + center_x;
@@ -153,7 +153,13 @@ void FaceWatch_CustomWindows::draw(bool force)
 			canvas[canvasid].setTextDatum(MC_DATUM);
 			canvas[canvasid].setFreeFont(RobotoMono_Regular[7]);
 			canvas[canvasid].setTextColor(winclock.color_titletext, winclock.color_titlebar);
-			canvas[canvasid].drawString(String(day) + "/" + String(month) + "/" + String(year), 85 + xo, 12 + yo);
+
+			String toolbar_date = String(day) + "/" + String(month) + "/" + String(year);
+			if (settings.config.time_dateformat == true) {
+				toolbar_date = String(month) + "/" + String(day) + "/" + String(year);
+			}
+
+			canvas[canvasid].drawString(toolbar_date, 85 + xo, 12 + yo);
 
 			// Menu Bar Text
 			canvas[canvasid].setTextDatum(ML_DATUM);
@@ -185,12 +191,16 @@ void FaceWatch_CustomWindows::draw(bool force)
 			if (hr_index > 59)
 				hr_index -= 60;
 
+			if (mins > 59)
+				mins -= 60;
+
 			// Seconds Hand
 			canvas[canvasid].drawWideLine(center_x, center_y, pos_secs[secs][0], pos_secs[secs][1], 1.0f, winclock.color_sechand);
 
 			// Minutes Hand
 			canvas[canvasid].drawWideLine(pos_lo[mins][0], pos_lo[mins][1], pos_mins[mins][0], pos_mins[mins][1], 1.0f, winclock.color_hrminhand);
 			canvas[canvasid].drawWideLine(pos_ro[mins][0], pos_ro[mins][1], pos_mins[mins][0], pos_mins[mins][1], 1.0f, winclock.color_hrminhand);
+		
 			// Mins Hand Rear
 			canvas[canvasid].drawWideLine(pos_lo[mins][0], pos_lo[mins][1], pos_mins_rlo[mins][0], pos_mins_rlo[mins][1], 1.0f, winclock.color_hrminhand);
 			canvas[canvasid].drawWideLine(pos_ro[mins][0], pos_ro[mins][1], pos_mins_rro[mins][0], pos_mins_rro[mins][1], 1.0f, winclock.color_hrminhand);
@@ -201,9 +211,6 @@ void FaceWatch_CustomWindows::draw(bool force)
 			// Hours Hand Rear
 			canvas[canvasid].drawWideLine(pos_lo[hr_index][0], pos_lo[hr_index][1], pos_hours_rlo[hr_index][0], pos_hours_rlo[hr_index][1], 1.0f, winclock.color_hrminhand);
 			canvas[canvasid].drawWideLine(pos_ro[hr_index][0], pos_ro[hr_index][1], pos_hours_rro[hr_index][0], pos_hours_rro[hr_index][1], 1.0f, winclock.color_hrminhand);
-
-			// Hour Debug
-			info_println("Index: " + String(hr_index) + ", index0: " + String(pos_hours[hr_index][0]) + ", index1: " + String(pos_hours[hr_index][1]));
 
 			// Clock Face Ends Here
 

--- a/Platform-io-source/src/tw_faces/face_Watch_CustomWindows.cpp
+++ b/Platform-io-source/src/tw_faces/face_Watch_CustomWindows.cpp
@@ -181,7 +181,7 @@ void FaceWatch_CustomWindows::draw(bool force)
 				hours -= 12;
 
 			// Move the hours hand with the precision of minutes
-			int hr_index = (hours * 5) + (mins / 5);
+			int hr_index = (hours * 5) + (mins / 12);
 
 			// Seconds Hand
 			canvas[canvasid].drawWideLine(center_x, center_y, pos_secs[secs][0], pos_secs[secs][1], 1.0f, winclock.color_sechand);

--- a/Platform-io-source/src/tw_faces/face_Watch_CustomWindows.cpp
+++ b/Platform-io-source/src/tw_faces/face_Watch_CustomWindows.cpp
@@ -1,0 +1,193 @@
+#include "tw_faces/face_Watch_CustomWindows.h"
+#include "bitmaps/bitmaps_general.h"
+#include "peripherals/battery.h"
+#include "peripherals/imu.h"
+#include "settings/settings.h"
+#include "tinywatch.h"
+#include "fonts/RobotoMono_Light_All.h"
+#include "fonts/RobotoMono_Regular_All.h"
+
+void FaceWatch_CustomWindows::setup()
+{
+	if (!is_setup)
+	{
+		is_setup = true;
+	}
+}
+
+// Pre calculate the trig required for the analog clock face as calculating trig on the fly is expensive on an MCU
+void FaceWatch_CustomWindows::setup_trig()
+{
+	int b = 0;
+	float i = -M_PI / 2.0;
+
+	for (int tick = 0; tick < 60; tick++)
+	{
+		if (tick % 5 == 0)
+		{
+			pos_hours[b][0] = ((face_radius - 60) * cos(i)) + center_x;
+			pos_hours[b][1] = ((face_radius - 60) * sin(i)) + center_y;
+			b++;
+		}
+
+		pos_mins[tick][0] = ((face_radius - 30) * cos(i)) + center_x;
+		pos_mins[tick][1] = ((face_radius - 30) * sin(i)) + center_y;
+		pos_secs[tick][0] = ((face_radius - 20) * cos(i)) + center_x;
+		pos_secs[tick][1] = ((face_radius - 20) * sin(i)) + center_y;
+
+		i += M_PI * 2.0 / 60.0;
+	}
+}
+
+void FaceWatch_CustomWindows::draw(bool force)
+{
+	if (force || millis() - next_update > update_period)
+	{
+		setup();
+
+		next_update = millis();
+
+		if (!is_dragging || !is_cached)
+		{
+			if (is_dragging)
+				is_cached = true;
+
+			if (!cachedTrig)
+			{
+				cachedTrig = true;
+				setup_trig();
+			}
+
+			uint8_t secs = rtc.get_seconds();
+
+			// Only fetch the mins, hrs, and date once a minute.
+			// Also do it for first run (year cant be 0, or 2000)
+			if (secs == 0 || year == 0 || year == 2000)
+			{
+				mins = rtc.get_mins();
+				hours = rtc.get_hours();
+				day = rtc.get_day();
+				month = rtc.get_month();
+				year = rtc.get_year();
+
+				// Offset the Date for single/multiple digits
+				if (day > 9)
+					day_offset = 0;
+			}
+
+			// Clock Face Starts Here
+			WindowsClockSettings winclock;
+
+			// Blank the display
+			canvas[canvasid].fillSprite(winclock.color_displaybkg);
+			canvas[canvasid].setTextColor(TFT_WHITE);
+
+			uint16_t xo = (display.width - winclock.width) / 2;
+			uint16_t yo = (display.height - winclock.height) / 2;
+
+			//  x, y, w , h
+			// Main Window
+			canvas[canvasid].fillRect(0 + xo, 0 + yo, winclock.width, winclock.height, winclock.color_background);		   // Clock window background
+			canvas[canvasid].drawRect(0 + xo, 0 + yo, winclock.width, winclock.height, winclock.color_borderedge);		   // Border outer edge
+			canvas[canvasid].drawRect(3 + xo, 3 + yo, winclock.width - 6, winclock.height - 6, winclock.color_borderedge); // Border inner edge
+
+			// Title Box
+			canvas[canvasid].fillRect(3 + xo, 3 + yo, winclock.width - 6, 20, winclock.color_titlebar);	  // Border title edge
+			canvas[canvasid].drawRect(3 + xo, 3 + yo, winclock.width - 6, 20, winclock.color_borderedge); // Border title edge
+
+			// Control Box
+			canvas[canvasid].fillRect(3 + xo, 3 + yo, 20, 20, winclock.color_background);	   // Control Box Background
+			canvas[canvasid].drawRect(3 + xo, 3 + yo, 20, 20, winclock.color_borderedge);	   // Control Box Border
+			canvas[canvasid].fillRect(7 + xo, 12 + yo, 13, 3, winclock.color_buttonshadow);	   // Control Box Minus Shadow
+			canvas[canvasid].fillRect(6 + xo, 11 + yo, 13, 3, winclock.color_buttonhighlight); // Control Box Minus Fill
+			canvas[canvasid].drawRect(6 + xo, 11 + yo, 13, 3, winclock.color_borderedge);	   // Control Box Minus Border
+
+			// Maximise Box
+			canvas[canvasid].fillRect((xo + winclock.width) - 23, 3 + yo, 20, 20, winclock.color_background); // Control Box Background
+			canvas[canvasid].drawRect((xo + winclock.width) - 23, 3 + yo, 20, 20, winclock.color_borderedge); // Control Box Border
+
+			canvas[canvasid].drawLine((xo + winclock.width) - 13, 11 + yo, (xo + winclock.width) - 13, 11 + yo, winclock.color_menutext);
+			canvas[canvasid].drawLine((xo + winclock.width) - 14, 12 + yo, (xo + winclock.width) - 12, 12 + yo, winclock.color_menutext);
+			canvas[canvasid].drawLine((xo + winclock.width) - 15, 13 + yo, (xo + winclock.width) - 11, 13 + yo, winclock.color_menutext);
+			canvas[canvasid].drawLine((xo + winclock.width) - 16, 14 + yo, (xo + winclock.width) - 10, 14 + yo, winclock.color_menutext);
+
+			// Minimise Box
+			canvas[canvasid].fillRect((xo + winclock.width) - 42, 3 + yo, 20, 20, winclock.color_background); // Control Box Background
+			canvas[canvasid].drawRect((xo + winclock.width) - 42, 3 + yo, 20, 20, winclock.color_borderedge); // Control Box Border
+
+			canvas[canvasid].drawLine((xo + winclock.width) - 32, 14 + yo, (xo + winclock.width) - 32, 14 + yo, winclock.color_menutext);
+			canvas[canvasid].drawLine((xo + winclock.width) - 33, 13 + yo, (xo + winclock.width) - 31, 13 + yo, winclock.color_menutext);
+			canvas[canvasid].drawLine((xo + winclock.width) - 34, 12 + yo, (xo + winclock.width) - 30, 12 + yo, winclock.color_menutext);
+			canvas[canvasid].drawLine((xo + winclock.width) - 35, 11 + yo, (xo + winclock.width) - 29, 11 + yo, winclock.color_menutext);
+
+			// Menu Box
+			canvas[canvasid].fillRect(3 + xo, 23 + yo, winclock.width - 6, 20, winclock.color_menubar);	   // Border title edge
+			canvas[canvasid].drawRect(3 + xo, 23 + yo, winclock.width - 6, 20, winclock.color_borderedge); // Border title edge
+
+			// Title Bar Date
+			canvas[canvasid].setTextDatum(MC_DATUM);
+			canvas[canvasid].setFreeFont(RobotoMono_Regular[7]);
+			canvas[canvasid].setTextColor(winclock.color_titletext, winclock.color_titlebar);
+			canvas[canvasid].drawString(String(day) + "/" + String(month) + "/" + String(year), 85 + xo, 12 + yo);
+
+			// Menu Bar Text
+			canvas[canvasid].setTextDatum(ML_DATUM);
+			canvas[canvasid].setFreeFont(RobotoMono_Regular[7]);
+			canvas[canvasid].setTextColor(winclock.color_menutext, winclock.color_menubar);
+			canvas[canvasid].drawString("Settings", 10 + xo, 32 + yo);
+			canvas[canvasid].drawLine(10 + xo, 39 + yo, 18 + xo, 39 + yo, winclock.color_menutext);
+
+			// Seconds Dots
+			for (int x = 0; x < 60; x++)
+			{
+				canvas[canvasid].fillRect(pos_secs[x][0] - 1, pos_secs[x][1] - 1, 2, 2, winclock.color_buttonshadow);
+				canvas[canvasid].fillRect(pos_secs[x][0], pos_secs[x][1], 2, 2, winclock.color_buttonhighlight);
+			}
+
+			// Hours Dots
+			for (int x = 0; x < 12; x++)
+			{
+				canvas[canvasid].fillRect(pos_secs[x*5][0] - 1, pos_secs[x*5][1] - 1, 5, 5, winclock.color_buttonshadow);
+				canvas[canvasid].fillRect(pos_secs[x*5][0] - 2, pos_secs[x*5][1] - 2, 5, 5, winclock.color_hourblock);
+			}
+
+			// Analog Clock Hands
+			if (hours > 12)
+				hours -= 12;
+
+			canvas[canvasid].drawWideLine(center_x, center_y, pos_hours[hours][0], pos_hours[hours][1], 4.0f, winclock.color_hrminhand);
+			canvas[canvasid].drawWideLine(center_x, center_y, pos_mins[mins][0], pos_mins[mins][1], 4.0f, winclock.color_hrminhand);
+			canvas[canvasid].drawWideLine(center_x, center_y, pos_secs[secs][0], pos_secs[secs][1], 1.0f, winclock.color_sechand);
+
+			// Clock Face Ends Here
+
+			draw_children(false, 0);
+		}
+
+		canvas[canvasid].pushSprite(_x, _y);
+	}
+}
+
+bool FaceWatch_CustomWindows::click(int16_t pos_x, int16_t pos_y)
+{
+	// Cycle through the colour pallette, after one full cycle, switch the style (square/circle)
+	return false;
+}
+
+bool FaceWatch_CustomWindows::click_double(int16_t pos_x, int16_t pos_y)
+{
+	display.cycle_clock_face();
+
+	is_dragging = false;
+	// draw(true);
+	return true;
+}
+
+bool FaceWatch_CustomWindows::click_long(int16_t pos_x, int16_t pos_y)
+{
+	// info_println("LOOOONG!");
+	// TODO: Add display of watch specific settings here when the user long presses
+	return true;
+}
+
+FaceWatch_CustomWindows face_watch_custom_windows;

--- a/Platform-io-source/src/tw_faces/face_Watch_CustomWindows.h
+++ b/Platform-io-source/src/tw_faces/face_Watch_CustomWindows.h
@@ -61,7 +61,14 @@ class FaceWatch_CustomWindows : public tw_face
 		bool cachedTrig = false;
 		float pos_secs[60][2];
 		float pos_mins[60][2];
-		float pos_hours[12][2];
+		float pos_lo[60][2];
+		float pos_ro[60][2];
+		float pos_mins_rlo[60][2];
+		float pos_mins_rro[60][2];
+		float pos_hours_rlo[60][2];
+		float pos_hours_rro[60][2];
+
+		float pos_hours[60][2];
 		int center_x = 120;
 		int center_y = 155;
 
@@ -70,3 +77,4 @@ class FaceWatch_CustomWindows : public tw_face
 };
 
 extern FaceWatch_CustomWindows face_watch_custom_windows;
+

--- a/Platform-io-source/src/tw_faces/face_Watch_CustomWindows.h
+++ b/Platform-io-source/src/tw_faces/face_Watch_CustomWindows.h
@@ -74,6 +74,8 @@ class FaceWatch_CustomWindows : public tw_face
 
 		float face_radius = 100;
 
+		int cnt = 0;
+		int cnth = 3;
 };
 
 extern FaceWatch_CustomWindows face_watch_custom_windows;

--- a/Platform-io-source/src/tw_faces/face_Watch_CustomWindows.h
+++ b/Platform-io-source/src/tw_faces/face_Watch_CustomWindows.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "tw_faces/tw_face.h"
+
+class FaceWatch_CustomWindows : public tw_face
+{
+	public:
+		void setup(void);
+		void draw(bool force);
+		bool click(int16_t pos_x, int16_t pos_y);
+		bool click_double(int16_t pos_x, int16_t pos_y);
+		bool click_long(int16_t pos_x, int16_t pos_y);
+
+	private:
+		String version = "3.11";
+		
+		struct WindowsClockSettings
+		{
+				uint16_t width = display.width - 50;
+				uint16_t height = display.height - 50;
+				uint16_t color_background = RGB(0xc3, 0xc7, 0xcb);		// Light Grey
+				uint16_t color_borderedge = RGB(0x00, 0x00, 0x00);		// Black
+				uint16_t color_titlebar = RGB(0x00, 0x00, 0xAA);		// Blue
+				uint16_t color_titletext = RGB(0xFF, 0xFF, 0xFF);		// Blue
+				uint16_t color_buttonshadow = RGB(0x86, 0x8A, 0x8E);	// Dark Grey
+				uint16_t color_buttonhighlight = RGB(0xFF, 0xFF, 0xFF); // White
+				uint16_t color_displaybkg = RGB(0x11, 0x11, 0x11);		// Black
+				uint16_t color_menubar = RGB(0xFF, 0xFF, 0xFF);			// Blue
+				uint16_t color_menutext = RGB(0x00, 0x00, 0x00);		// Blue
+				uint16_t color_hrminhand = RGB(0x00, 0x00, 0x00);		// Black
+				uint16_t color_sechand = RGB(0x88, 0x88, 0x88);			// Grey
+				uint16_t color_hourblock = RGB(85, 170, 170);				// Aqua
+
+		};
+
+		struct Box
+		{
+				int16_t x1;
+				int16_t x2;
+				int16_t y1;
+				int16_t y2;
+				uint16_t color;
+		};
+
+		const String months[12] = {"JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"};
+
+		// Settings
+		bool show_borders = true;
+
+		// Kept for Caching
+		uint8_t hours = 0;
+		uint8_t mins = 0;
+		uint16_t day = 0;
+		uint16_t month = 0;
+		uint16_t year = 0;
+		int8_t day_offset = -16;
+
+		// UM Analog Clock Stuff
+		void setup_trig(void);
+		void draw_hand(int x, int y, int x1, int y1, uint16_t color);
+		bool cachedTrig = false;
+		float pos_secs[60][2];
+		float pos_mins[60][2];
+		float pos_hours[12][2];
+		int center_x = 120;
+		int center_y = 155;
+
+		float face_radius = 100;
+
+};
+
+extern FaceWatch_CustomWindows face_watch_custom_windows;


### PR DESCRIPTION
Created a clock face that pays homage to the classic Windows 3.1/3.11 Clock app.
New: Classic wireframe hour/minute hands.
New: Hour hand reflects minutes-level precision
New: Added Date Format Setting (DMY/MDY). Currently honoured by WinClock
Fix: Fixed precision calculation.
Fix: But with the rear of the hands displaying correctly at midday, or on the hour.
TODO - Work out how to integrate battery/WIFI/activity widgets into face
