### PR TITLE
Add compass calibration and tilt compensation

### DIFF
--- a/Platform-io-source/src/peripherals/imu.cpp
+++ b/Platform-io-source/src/peripherals/imu.cpp
@@ -367,7 +367,7 @@ float IMU::get_roll()
 	return (atan2((imu.data.accelX), sqrt(imu.data.accelY * imu.data.accelY + imu.data.accelZ * imu.data.accelZ)) * 57.3);
 }
 
-void IMU::get_magnetic(float *x, float *y, float *z, bool compensated)
+void IMU::get_magnetic(float *x, float *y, float *z, bool iron_compensated)
 {
 	if (mag_ready)
 	{

--- a/Platform-io-source/src/peripherals/imu.cpp
+++ b/Platform-io-source/src/peripherals/imu.cpp
@@ -399,7 +399,7 @@ void IMU::get_magnetic(float *x, float *y, float *z, bool iron_compensated)
 }
 
 /*
-	Resource used to tile correct the yaw
+	Resource used to tilt correct the yaw
 	https://www.instructables.com/Tilt-Compensated-Compass/
 */
 float IMU::get_yaw(bool tilt_compensated)

--- a/Platform-io-source/src/peripherals/imu.cpp
+++ b/Platform-io-source/src/peripherals/imu.cpp
@@ -384,14 +384,14 @@ float IMU::get_yaw()
 	// Apply hard-iron calibration
 	float hi_cal[3] =
 	{
-		mag_data[0] - settings.config.compass.hard_iron[0],
-		mag_data[1] - settings.config.compass.hard_iron[1],
-		mag_data[2] - settings.config.compass.hard_iron[2]
+		mag_data[0] - settings.config.compass.hard_iron_x,
+		mag_data[1] - settings.config.compass.hard_iron_y,
+		mag_data[2] - settings.config.compass.hard_iron_z
 	};	
 	
 	// Apply soft-iron matrix
 	for (uint8_t i = 0; i < 3; i++)	
-		mag_data[i] = (settings.config.compass.soft_iron[i][0] * hi_cal[0]) + (settings.config.compass.soft_iron[i][1] * hi_cal[1]) + (settings.config.compass.soft_iron[i][2] * hi_cal[2]);
+		mag_data[i] = (soft_iron[i][0] * hi_cal[0]) + (soft_iron[i][1] * hi_cal[1]) + (soft_iron[i][2] * hi_cal[2]);
 	
 	// Non tilt compensated compass heading
 	// DB: The orientations of the sensor means we should use atan2(y,x) instead of atan2(x,y) and it also has a -90 deg offset 

--- a/Platform-io-source/src/peripherals/imu.h
+++ b/Platform-io-source/src/peripherals/imu.h
@@ -20,7 +20,7 @@ class IMU
 		float get_gyro_z();
 		float get_pitch();
 		float get_roll();
-		float get_yaw();
+		float get_yaw(bool tilt_compensated = true);
 		void get_magnetic(float *x, float *y, float *z, bool compensated = true);
 		
 		bool is_looking_at_face();

--- a/Platform-io-source/src/peripherals/imu.h
+++ b/Platform-io-source/src/peripherals/imu.h
@@ -21,7 +21,7 @@ class IMU
 		float get_pitch();
 		float get_roll();
 		float get_yaw(bool tilt_compensated = true);
-		void get_magnetic(float *x, float *y, float *z, bool compensated = true);
+		void get_magnetic(float *x, float *y, float *z, bool iron_compensated = true);
 		
 		bool is_looking_at_face();
 

--- a/Platform-io-source/src/peripherals/imu.h
+++ b/Platform-io-source/src/peripherals/imu.h
@@ -56,9 +56,6 @@ class IMU
 		float curr_yaw_read = 0;
 		float hacky_yaw = 0;
 		
-		// this should be specific to the unit and not location, so no need to save per user preferences
-		float soft_iron[3][3] = {{1.003, 0.008, -0.001}, {0.008, 1.004, 0.000}, {-0.001, -0.000, 0.994}}; // {{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}}; // 
-
 		uint32_t step_count = 0;
 		uint8_t movement_activity = 0;
 

--- a/Platform-io-source/src/peripherals/imu.h
+++ b/Platform-io-source/src/peripherals/imu.h
@@ -55,6 +55,9 @@ class IMU
 		float prev_yaw_read = 0;
 		float curr_yaw_read = 0;
 		float hacky_yaw = 0;
+		
+		// this should be specific to the unit and not location, so no need to save per user preferences
+		float soft_iron[3][3] = {{1.003, 0.008, -0.001}, {0.008, 1.004, 0.000}, {-0.001, -0.000, 0.994}}; // {{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}}; // 
 
 		uint32_t step_count = 0;
 		uint8_t movement_activity = 0;

--- a/Platform-io-source/src/peripherals/imu.h
+++ b/Platform-io-source/src/peripherals/imu.h
@@ -21,7 +21,7 @@ class IMU
 		float get_pitch();
 		float get_roll();
 		float get_yaw();
-		void get_magnetic(float *x, float *y, float *z);
+		void get_magnetic(float *x, float *y, float *z, bool compensated = true);
 		
 		bool is_looking_at_face();
 

--- a/Platform-io-source/src/peripherals/imu.h
+++ b/Platform-io-source/src/peripherals/imu.h
@@ -21,6 +21,8 @@ class IMU
 		float get_pitch();
 		float get_roll();
 		float get_yaw();
+		void get_magnetic(float *x, float *y, float *z);
+		
 		bool is_looking_at_face();
 
 		void set_hibernate(bool state);
@@ -56,15 +58,6 @@ class IMU
 
 		uint32_t step_count = 0;
 		uint8_t movement_activity = 0;
-
-		// Magnetometer Calibration
-		// Hard-iron calibration settings
-		const float hard_iron[3] = {17.77, -30.08, 16.21};
-
-		// Soft-iron calibration settings
-		const float soft_iron[3][3] = {{1.003, 0.008, -0.001}, {0.008, 1.004, 0.000}, {-0.001, -0.000, 0.994}};
-
-		const float mag_decl = -1.233;
 
 		bool persist_step_count();
 };

--- a/Platform-io-source/src/settings/settings.cpp
+++ b/Platform-io-source/src/settings/settings.cpp
@@ -20,7 +20,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Config_custom_binary, binary_clo
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Config_app_microphone, sweep_size, gain_factor);
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Config_compass, hard_iron_x, hard_iron_y, hard_iron_z, magnetic_declination);
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Config_compass, hard_iron_x, hard_iron_y, hard_iron_z, soft_iron_x, soft_iron_y, soft_iron_z, magnetic_declination);
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Config, wifi_start, wifi_ssid, wifi_pass, mdns_name, website_darkmode, mqtt, battery, open_weather, city, country, utc_offset, bl_period_vbus, bl_period_vbat, time_24hour, time_dateformat, clock_face_index, left_handed, flipped, audio_ui, audio_alarm, imu_process_steps, imu_process_wrist, app_microphone, compass, custom_binary);
 

--- a/Platform-io-source/src/settings/settings.cpp
+++ b/Platform-io-source/src/settings/settings.cpp
@@ -20,7 +20,9 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Config_custom_binary, binary_clo
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Config_app_microphone, sweep_size, gain_factor);
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Config, wifi_start, wifi_ssid, wifi_pass, mdns_name, website_darkmode, mqtt, battery, open_weather, city, country, utc_offset, bl_period_vbus, bl_period_vbat, time_24hour, time_dateformat, clock_face_index, left_handed, flipped, audio_ui, audio_alarm, imu_process_steps, imu_process_wrist, app_microphone, custom_binary);
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Config_compass, hard_iron_x, hard_iron_y, hard_iron_z, magnetic_declination);
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Config, wifi_start, wifi_ssid, wifi_pass, mdns_name, website_darkmode, mqtt, battery, open_weather, city, country, utc_offset, bl_period_vbus, bl_period_vbat, time_24hour, time_dateformat, clock_face_index, left_handed, flipped, audio_ui, audio_alarm, imu_process_steps, imu_process_wrist, app_microphone, compass, custom_binary);
 
 
 void Settings::log_to_nvs(const char *key, const char *log)

--- a/Platform-io-source/src/settings/settings.h
+++ b/Platform-io-source/src/settings/settings.h
@@ -41,6 +41,9 @@ struct Config
 		// Microphone App specific Settings
 		Config_app_microphone app_microphone;
 
+		// Compass specific settings
+		Config_compass compass;
+
 		// Display
 		uint bl_period_vbus = 60000;
 		uint bl_period_vbat = 30000;

--- a/Platform-io-source/src/settings/settings_extra.h
+++ b/Platform-io-source/src/settings/settings_extra.h
@@ -74,5 +74,8 @@ struct Config_compass
 		float hard_iron_x = 0;
 		float hard_iron_y = 0;
 		float hard_iron_z = 0;
+		float soft_iron_x = 1;
+		float soft_iron_y = 1;
+		float soft_iron_z = 1;
 		float magnetic_declination = 0.0; //-1.233;
 };

--- a/Platform-io-source/src/settings/settings_extra.h
+++ b/Platform-io-source/src/settings/settings_extra.h
@@ -64,3 +64,13 @@ struct Config_app_microphone
 		uint8_t sweep_size = 1;
 		uint8_t gain_factor = 0;
 };
+
+/**
+ * @brief Settings required by the compass
+ */
+struct Config_compass
+{
+		float hard_iron[3] = { 0, 0, 0 }; // {17.77, -30.08, 16.21};
+		float soft_iron[3][3] = {{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}}; // {{1.003, 0.008, -0.001}, {0.008, 1.004, 0.000}, {-0.001, -0.000, 0.994}}; // 
+		float magnetic_declination = 0.0; //-1.233;
+};

--- a/Platform-io-source/src/settings/settings_extra.h
+++ b/Platform-io-source/src/settings/settings_extra.h
@@ -70,7 +70,9 @@ struct Config_app_microphone
  */
 struct Config_compass
 {
-		float hard_iron[3] = { 0, 0, 0 }; // {17.77, -30.08, 16.21};
-		float soft_iron[3][3] = {{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}}; // {{1.003, 0.008, -0.001}, {0.008, 1.004, 0.000}, {-0.001, -0.000, 0.994}}; // 
+		// {17.77, -30.08, 16.21};
+		float hard_iron_x = 0;
+		float hard_iron_y = 0;
+		float hard_iron_z = 0;
 		float magnetic_declination = 0.0; //-1.233;
 };

--- a/Platform-io-source/src/tw_apps/app_Compass.cpp
+++ b/Platform-io-source/src/tw_apps/app_Compass.cpp
@@ -71,23 +71,33 @@ bool AppCompass::process_touch(touch_event_t touch_event)
 		}
 		else if (running_state == RUNNING_STATE_CALIBRATE && touch_event.dir == TOUCH_SWIPE_UP)
 		{
-			settings.config.compass.hard_iron_x = hard_iron_x;
-			settings.config.compass.hard_iron_y = hard_iron_y;
-			settings.config.compass.hard_iron_z = hard_iron_z;
+ 			// https://github.com/kriswiner/MPU6050/wiki/Simple-and-Effective-Magnetometer-Calibration
 
-			settings.config.compass.soft_iron_x = soft_iron_x;
-			settings.config.compass.soft_iron_y = soft_iron_y;
-			settings.config.compass.soft_iron_z = soft_iron_z;
+			float soft_iron_x = (mag_x_max - mag_x_min) / 2;
+			float soft_iron_y = (mag_y_max - mag_y_min) / 2;
+			float soft_iron_z = (mag_z_max - mag_z_min) / 2;
+		
+			float soft_scale = (soft_iron_x + soft_iron_y + soft_iron_z) / 3;
+
+			settings.config.compass.hard_iron_x = (mag_x_max + mag_x_min) / 2;
+			settings.config.compass.hard_iron_y = (mag_y_max + mag_y_min) / 2;
+			settings.config.compass.hard_iron_z = (mag_z_max + mag_z_min) / 2;
+
+			settings.config.compass.soft_iron_x = soft_scale / soft_iron_x;
+			settings.config.compass.soft_iron_y = soft_scale / soft_iron_y;
+			settings.config.compass.soft_iron_z = soft_scale / soft_iron_z;
 
 			settings.save(true);
-			info_print(F("Compass hard iron values saved"));			
+			info_print(F("Compass calibration values saved"));
+
 			running_state = RUNNING_STATE_DRAW;
 			return true;
 		}
 	}
 	else if (touch_event.type == TOUCH_TAP)
 	{
-		resetCalibration();
+		resetCalibration();		
+		//canvas[canvasid].drawSmoothCircle(touch_event.x, touch_event.y, 3, TFT_ORANGE, TFT_TRANSPARENT);
 	}
 	return false;
 }
@@ -137,18 +147,11 @@ void AppCompass::resetCalibration()
 	mag_y_max = -6000;
 	mag_z_max = -6000;
 	
-	hard_iron_x = 0;
-	hard_iron_y = 0;
-	hard_iron_z = 0;
-
-	soft_iron_x = 1;
-	soft_iron_y = 1;
-	soft_iron_z = 1;
+	canvas[canvasid].fillSprite(TFT_BLACK);
 }
 
 /**
- * https://www.instructables.com/Tilt-Compensated-Compass/
- * https://github.com/kriswiner/MPU6050/wiki/Simple-and-Effective-Magnetometer-Calibration
+ *
  */
 void AppCompass::drawCalibrate()
 {
@@ -166,78 +169,29 @@ void AppCompass::drawCalibrate()
 	mag_y_max = max(mag_y, mag_y_max);
 	mag_z_max = max(mag_z, mag_z_max);
 
-	hard_iron_x = (mag_x_max + mag_x_min) / 2;
-	hard_iron_y = (mag_y_max + mag_y_min) / 2;
-	hard_iron_z = (mag_z_max + mag_z_min) / 2;
+	canvas[canvasid].fillSprite(TFT_BLACK);
 
-	soft_iron_x = (mag_x_max - mag_x_min) / 2;
-	soft_iron_y = (mag_y_max - mag_y_min) / 2;
-	soft_iron_z = (mag_z_max - mag_z_min) / 2;
- 
-	float soft_scale = (soft_iron_x + soft_iron_y + soft_iron_z) / 3;
-
-	soft_iron_x = soft_scale / soft_iron_x;
-	soft_iron_y = soft_scale / soft_iron_y;
-	soft_iron_z = soft_scale / soft_iron_z;
-
-	canvas[canvasid].fillSprite(TFT_TRANSPARENT);
-	canvas[canvasid].setFreeFont(RobotoMono_Regular[12]);
+	canvas[canvasid].setFreeFont(RobotoMono_Regular[9]);
 	
 	canvas[canvasid].setTextColor(TFT_WHITE);
 	canvas[canvasid].setTextDatum(CC_DATUM);
-	canvas[canvasid].drawString("Calibrating", display.width / 2, 10);		
-		
-	float right1 = display.width - 180;
-	float right2 = display.width - 100;
-	float right3 = display.width -  20;
-	float top = 20;
-		
-	canvas[canvasid].setTextDatum(CR_DATUM);
-
-	canvas[canvasid].setTextColor(TFT_WHITE);
-	top += 30;
-	// current hard iron settings
-	canvas[canvasid].drawString(String(settings.config.compass.hard_iron_x, 1), right1, top);
-	canvas[canvasid].drawString(String(settings.config.compass.hard_iron_y, 1), right2, top);
-	canvas[canvasid].drawString(String(settings.config.compass.hard_iron_z, 1), right3, top);
+	canvas[canvasid].drawString("Calibrating", display.width / 2, 20);		
 	
-	canvas[canvasid].setTextColor(TFT_GREEN);
-	top += 30;
-	// new hard iron settings
-	canvas[canvasid].drawString(String(hard_iron_x, 1), right1, top);
-	canvas[canvasid].drawString(String(hard_iron_y, 1), right2, top);
-	canvas[canvasid].drawString(String(hard_iron_z, 1), right3, top);	
-
-	canvas[canvasid].setTextColor(TFT_ORANGE);
-	top += 30;
-	// magnetic min values
-	canvas[canvasid].drawString(String(mag_x_min, 1), right1, top);
-	canvas[canvasid].drawString(String(mag_y_min, 1), right2, top);
-	canvas[canvasid].drawString(String(mag_z_min, 1), right3, top);
-
-	top += 30;
-	// magnetic max values
-	canvas[canvasid].drawString(String(mag_x_max, 1), right1, top);
-	canvas[canvasid].drawString(String(mag_y_max, 1), right2, top);
-	canvas[canvasid].drawString(String(mag_z_max, 1), right3, top);
+	//canvas[canvasid].drawPixel(display.center_x + mag_x, display.center_y + mag_y, TFT_RED);
+	//canvas[canvasid].drawPixel(display.center_x + mag_y, display.center_y + mag_z, TFT_GREEN);
+	//canvas[canvasid].drawPixel(display.center_x + mag_z, display.center_y + mag_x, TFT_BLUE);
 	
-	canvas[canvasid].setTextColor(TFT_WHITE);
-	top += 30;
-	// current soft iron settings
-	canvas[canvasid].drawString(String(settings.config.compass.soft_iron_x, 2), right1, top);
-	canvas[canvasid].drawString(String(settings.config.compass.soft_iron_y, 2), right2, top);
-	canvas[canvasid].drawString(String(settings.config.compass.soft_iron_z, 2), right3, top);
-	
-	canvas[canvasid].setTextColor(TFT_GREEN);
-	top += 30;
-	// new soft iron settings
-	canvas[canvasid].drawString(String(soft_iron_x, 2), right1, top);
-	canvas[canvasid].drawString(String(soft_iron_y, 2), right2, top);
-	canvas[canvasid].drawString(String(soft_iron_z, 2), right3, top);
+	//float xx = (mag_x_max + mag_x_min) / 2;
+	//float yy = (mag_y_max + mag_y_min) / 2;
+	//float zz = (mag_z_max + mag_z_min) / 2;
 
-	canvas[canvasid].setTextColor(TFT_WHITE);
-	canvas[canvasid].setTextDatum(CL_DATUM);
-	canvas[canvasid].drawString("/\\", 0, 260);
+	//canvas[canvasid].drawSmoothCircle(display.center_x + xx, display.center_y + yy, abs(mag_x_max - mag_x_min) / 2, TFT_RED, TFT_TRANSPARENT);
+	//canvas[canvasid].drawSmoothCircle(display.center_x + yy, display.center_y + zz, abs(mag_y_max - mag_y_min) / 2, TFT_GREEN, TFT_TRANSPARENT);
+	//canvas[canvasid].drawSmoothCircle(display.center_x + zz, display.center_y + xx, abs(mag_z_max - mag_z_min) / 2, TFT_BLUE, TFT_TRANSPARENT);
+
+	canvas[canvasid].drawSmoothCircle(display.center_x, display.center_y, abs(mag_x_max - mag_x_min) / 2, TFT_RED, TFT_TRANSPARENT);
+	canvas[canvasid].drawSmoothCircle(display.center_x, display.center_y, abs(mag_y_max - mag_y_min) / 2, TFT_GREEN, TFT_TRANSPARENT);
+	canvas[canvasid].drawSmoothCircle(display.center_x, display.center_y, abs(mag_z_max - mag_z_min) / 2, TFT_BLUE, TFT_TRANSPARENT);
 }
 
 /**
@@ -253,8 +207,8 @@ void AppCompass::drawCompass()
 		: newHeading - 360.0 - heading
 	;
 	heading = abs(a) < abs(b)
-		? heading + a
-		: heading + b
+		? heading + a * 0.5 // 0.5 dampen change in heading
+		: heading + b * 0.5 // 0.5 dampen change in heading
 	;
 
 	if (heading >= 360.0)
@@ -262,9 +216,7 @@ void AppCompass::drawCompass()
 	if (heading < 0.0)
 		heading += 360.0;
 
-	// TFT_TRANSPARENT is a special colour with reversible 8/16 bit coding
-	// this allows it to be used in both 8 and 16 bit colour sprites.
-	canvas[canvasid].fillSprite(TFT_TRANSPARENT);
+	canvas[canvasid].fillSprite(TFT_BLACK);
 
 	canvas[canvasid].setTextColor(TFT_WHITE);
 	canvas[canvasid].setTextDatum(CL_DATUM);
@@ -273,25 +225,25 @@ void AppCompass::drawCompass()
 	canvas[canvasid].drawCircle(120, 140, 30, TFT_DARKGREY);
 
 	/*
-	 Rotate a unit 1 vector pointing down (Cartesian coordinate) [x: 0, y: 1] around the origin at given angle
-	 we can reduce the calcs in the rotation matrix due to the x component being 0 and y being 1
+	 Rotate a unit 1 vector pointing down (Cartesian coordinate) [x: 0, y: 1] around the origin at the given angle
+	 We can reduce the calcs in the rotation matrix due to the x component being 0 and y being 1
 	 
-	 xp = x * cos(a) - y * sin(a)
-	 yp = y * cos(a) + x * sin(a)
+	 xp = x(0) * cos(a) - y(1) * sin(a)
+	 yp = y(1) * cos(a) + x(0) * sin(a)
 	 
-	 this recuces down to
+	 This recuces down to
 	 
 	 xp = -y * sin(a)
 	 yp =  y * cos(a)
 	 
-	 the result is a normalized vector that can then be multiplied by a radius, using left hand rule
+	 The result is a normalized rotated vector that can then be multiplied by a radius
 	*/
 	
-	// we can multiply these normals with a radius to get all the coords we need
-	float normal_x, normal_y, normal_x_90, normal_y_90;
 	float heading_in_rad = heading * DEG_TO_RAD;
 	
-	// get the rotated up normalised vector
+	float normal_x, normal_y, normal_x_90, normal_y_90;	
+	
+	// get the rotated normalised vector
 	normal_x = -sin(heading_in_rad);
 	normal_y =  cos(heading_in_rad);
 
@@ -299,15 +251,15 @@ void AppCompass::drawCompass()
 	normal_x_90 = -normal_y;
 	normal_y_90 =  normal_x;
 
-	text_N_x = display.center_x - NESW_RADIUS * normal_x;
-	text_N_y = display.center_y - NESW_RADIUS * normal_y;
-	text_S_x = display.center_x + NESW_RADIUS * normal_x;
-	text_S_y = display.center_y + NESW_RADIUS * normal_y;
+	uint8_t text_N_x = display.center_x - NESW_RADIUS * normal_x;
+	uint8_t text_N_y = display.center_y - NESW_RADIUS * normal_y;
+	uint8_t text_S_x = display.center_x + NESW_RADIUS * normal_x;
+	uint8_t text_S_y = display.center_y + NESW_RADIUS * normal_y;
 
-	text_E_x = display.center_x - NESW_RADIUS * normal_x_90 * 0.6;
-	text_E_y = display.center_y - NESW_RADIUS * normal_y_90 * 0.6;	
-	text_W_x = display.center_x + NESW_RADIUS * normal_x_90 * 0.6;
-	text_W_y = display.center_y + NESW_RADIUS * normal_y_90 * 0.6;
+	uint8_t text_E_x = display.center_x - NESW_RADIUS * normal_x_90 * 0.6;
+	uint8_t text_E_y = display.center_y - NESW_RADIUS * normal_y_90 * 0.6;	
+	uint8_t text_W_x = display.center_x + NESW_RADIUS * normal_x_90 * 0.6;
+	uint8_t text_W_y = display.center_y + NESW_RADIUS * normal_y_90 * 0.6;
 
 	canvas[canvasid].setFreeFont(RobotoMono_Regular[12]);
 	canvas[canvasid].setTextColor(TFT_RED);
@@ -318,17 +270,18 @@ void AppCompass::drawCompass()
 	canvas[canvasid].drawString("S", text_S_x, text_S_y);
 	canvas[canvasid].drawString("W", text_W_x, text_W_y);
 	canvas[canvasid].setTextColor(TFT_ORANGE);
-	canvas[canvasid].drawString(String(heading, 2), display.width / 2, 240);
+	uint8_t l = canvas[canvasid].drawString(String(heading, 0), display.center_x, 240);
+	canvas[canvasid].drawSmoothCircle(display.center_x + l - 8, 236, 3, TFT_ORANGE, TFT_TRANSPARENT);
 
-	needle_N_x = display.center_x - NEEDLE_L * normal_x;
-	needle_N_y = display.center_y - NEEDLE_L * normal_y;
-	needle_S_x = display.center_x + NEEDLE_L * normal_x;
-	needle_S_y = display.center_y + NEEDLE_L * normal_y;
+	uint8_t needle_N_x = display.center_x - NEEDLE_L * normal_x;
+	uint8_t needle_N_y = display.center_y - NEEDLE_L * normal_y;
+	uint8_t needle_S_x = display.center_x + NEEDLE_L * normal_x;
+	uint8_t needle_S_y = display.center_y + NEEDLE_L * normal_y;
 
-	needle_E_x = display.center_x - NEEDLE_W * normal_x_90;
-	needle_E_y = display.center_y - NEEDLE_W * normal_y_90;
-	needle_W_x = display.center_x + NEEDLE_W * normal_x_90;
-	needle_W_y = display.center_y + NEEDLE_W * normal_y_90;
+	uint8_t needle_E_x = display.center_x - NEEDLE_W * normal_x_90;
+	uint8_t needle_E_y = display.center_y - NEEDLE_W * normal_y_90;
+	uint8_t needle_W_x = display.center_x + NEEDLE_W * normal_x_90;
+	uint8_t needle_W_y = display.center_y + NEEDLE_W * normal_y_90;
 
 	canvas[canvasid].fillTriangle(needle_N_x, needle_N_y, needle_E_x, needle_E_y, needle_W_x, needle_W_y, TFT_RED);
 	canvas[canvasid].fillTriangle(needle_S_x, needle_S_y, needle_E_x, needle_E_y, needle_W_x, needle_W_y, TFT_LIGHTGREY);

--- a/Platform-io-source/src/tw_apps/app_Compass.cpp
+++ b/Platform-io-source/src/tw_apps/app_Compass.cpp
@@ -3,10 +3,11 @@
 #include "fonts/Clock_Digits.h"
 #include "fonts/RobotoMono_Regular_All.h"
 #include "peripherals/imu.h"
+#include "settings/settings.h"
 
-#define RAD2DEG 0.0174532925
-#define BACKGROUND TFT_BLACK
-
+/**
+ * 
+ */
 void AppCompass::setup()
 {
 	if (!is_setup)
@@ -22,7 +23,10 @@ void AppCompass::setup()
  * This is not the same as setup() above that only ever gets called the first time the app opens
  *
  */
-void AppCompass::pre_start() {}
+void AppCompass::pre_start() 
+{
+	running_state = RUNNING_STATE_DRAW;
+}
 
 /**
  * @brief Draw the icon that gets shown on the app menu face
@@ -52,6 +56,36 @@ void AppCompass::draw_icon(uint8_t canvasid, int16_t _pos_x, int16_t _pos_y, uin
 	icon_sprite.pushToSprite(&canvas[canvasid], _pos_x, _pos_y);
 }
 
+/**
+ * 
+ */
+bool AppCompass::process_touch(touch_event_t touch_event)
+{
+	if (touch_event.type == TOUCH_SWIPE)
+	{
+		if (running_state == RUNNING_STATE_DRAW && touch_event.dir == TOUCH_SWIPE_DOWN)
+		{
+			resetCalibration();
+			running_state = RUNNING_STATE_CALIBRATE;
+			return true;
+		}
+		else if (running_state == RUNNING_STATE_CALIBRATE && touch_event.dir == TOUCH_SWIPE_UP)
+		{
+			settings.config.compass.hard_iron[0] = hard_iron_avg[0];
+			settings.config.compass.hard_iron[1] = hard_iron_avg[1];
+			settings.config.compass.hard_iron[2] = hard_iron_avg[2];
+			settings.save(true);
+			info_print(F("Compass hard iron values saved"));			
+			running_state = RUNNING_STATE_DRAW;
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * 
+ */
 void AppCompass::draw(bool force)
 {
 	// Override the CPU settings for this app (if needed)
@@ -60,64 +94,214 @@ void AppCompass::draw(bool force)
 	if (force || millis() - next_update > update_period)
 	{
 		setup();
-
 		next_update = millis();
-		angle = imu.get_yaw();
 
-		drawCompass(120, 140, angle); // Draw centre of compass at 120,140
+		heading = moveTowardsHeading(heading, imu.get_yaw());
+
+		switch(running_state)
+		{
+			case RUNNING_STATE_DRAW:
+			{
+				drawCompass(120, 140, heading); // Draw centre of compass at 120,140
+				break;
+			}
+
+			case RUNNING_STATE_CALIBRATE:
+			{
+				drawCalibrate();
+				break;
+			}
+		}
+
 		canvas[canvasid].pushSprite(_x, _y);
 	}
 }
 
-void AppCompass::drawCompass(int x, int y, int angle)
+/**
+ * 	@brief Move one heading towards another (0.0 > 360.0)
+ */
+float AppCompass::moveTowardsHeading(float currentHeading, float newHeading)
 {
-	canvas[canvasid].setFreeFont(RobotoMono_Regular[12]);
+	newHeading = newHeading;
 
+	float result;
+	float a = newHeading - currentHeading;
+	float b = newHeading < currentHeading
+		? newHeading + 360.0 - currentHeading 
+		: newHeading - 360.0 - currentHeading
+	;
+	result = abs(a) < abs(b)
+		? currentHeading + a * align_rate
+		: currentHeading + b * align_rate
+	;
+
+	if (result >= 360.0)
+		result -= 360.0;
+	if (result < 0.0)
+		result += 360.0;
+
+	return result;
+}
+
+/**
+ * 
+ */
+void AppCompass::resetCalibration()
+{
+	for(uint8_t i=0; i < 3; i++)
+	{
+		hard_iron_avg[i] = 0;
+		hard_iron_min[i] = std::numeric_limits<float>::max();
+		hard_iron_max[i] = std::numeric_limits<float>::min();
+	}
+}
+
+/**
+ * 
+ */
+void AppCompass::drawCalibrate()
+{
+	float mag[3];
+	imu.get_magnetic(&mag[0], &mag[1], &mag[2]);
+
+	if (mag[0] < hard_iron_min[0]) hard_iron_min[0] = mag[0];
+	if (mag[0] > hard_iron_max[0]) hard_iron_max[0] = mag[0];
+
+	if (mag[1] < hard_iron_min[1]) hard_iron_min[1] = mag[1];
+	if (mag[1] > hard_iron_max[1]) hard_iron_max[1] = mag[1];
+
+	if (mag[2] < hard_iron_min[2]) hard_iron_min[2] = mag[2];
+	if (mag[2] > hard_iron_max[2]) hard_iron_max[2] = mag[2];
+
+	hard_iron_avg[0] = hard_iron_min[0] + ((hard_iron_max[0] - hard_iron_min[0]) / 2);
+	hard_iron_avg[1] = hard_iron_min[1] + ((hard_iron_max[1] - hard_iron_min[1]) / 2);
+	hard_iron_avg[2] = hard_iron_min[2] + ((hard_iron_max[2] - hard_iron_min[2]) / 2);
+
+	canvas[canvasid].fillSprite(TFT_TRANSPARENT);
+
+	canvas[canvasid].setFreeFont(RobotoMono_Regular[12]);
+	
+	canvas[canvasid].setTextColor(TFT_WHITE);
+	canvas[canvasid].setTextDatum(CC_DATUM);
+	canvas[canvasid].drawString("Calibrating", display.width / 2, 40);
+	
+	canvas[canvasid].setTextColor(TFT_ORANGE);
+	canvas[canvasid].drawString("Hard Iron", display.width / 2, 80);
+	
+	canvas[canvasid].setTextColor(TFT_RED);
+	canvas[canvasid].setTextDatum(CL_DATUM);
+	canvas[canvasid].drawString("X:", display.width *.25, 110);
+	canvas[canvasid].setTextDatum(CR_DATUM);
+	canvas[canvasid].drawString(String(hard_iron_avg[0], 0), display.width *.75, 110);
+
+	canvas[canvasid].setTextColor(TFT_GREEN);
+	canvas[canvasid].setTextDatum(CL_DATUM);
+	canvas[canvasid].drawString("Y:", display.width *.25, 130);
+	canvas[canvasid].setTextDatum(CR_DATUM);
+	canvas[canvasid].drawString(String(hard_iron_avg[1], 0), display.width *.75, 130);
+
+	canvas[canvasid].setTextColor(TFT_BLUE);
+	canvas[canvasid].setTextDatum(CL_DATUM);
+	canvas[canvasid].drawString("Z:", display.width *.25, 150);
+	canvas[canvasid].setTextDatum(CR_DATUM);
+	canvas[canvasid].drawString(String(hard_iron_avg[2], 0), display.width *.75, 150);
+
+	canvas[canvasid].setTextColor(TFT_WHITE);
+	canvas[canvasid].setTextDatum(CC_DATUM);
+	canvas[canvasid].drawString("Current", display.width / 2, 190);	
+
+	canvas[canvasid].setTextColor(TFT_ORANGE);
+	canvas[canvasid].setTextDatum(CL_DATUM);
+	canvas[canvasid].drawString("X:", display.width *.25, 210);
+	canvas[canvasid].setTextDatum(CR_DATUM);
+	canvas[canvasid].drawString(String(settings.config.compass.hard_iron[0], 0), display.width *.75, 210);
+
+	canvas[canvasid].setTextColor(TFT_ORANGE);
+	canvas[canvasid].setTextDatum(CL_DATUM);
+	canvas[canvasid].drawString("X:", display.width *.25, 230);
+	canvas[canvasid].setTextDatum(CR_DATUM);
+	canvas[canvasid].drawString(String(settings.config.compass.hard_iron[1], 0), display.width *.75, 230);
+
+	canvas[canvasid].setTextColor(TFT_ORANGE);
+	canvas[canvasid].setTextDatum(CL_DATUM);
+	canvas[canvasid].drawString("X:", display.width *.25, 250);
+	canvas[canvasid].setTextDatum(CR_DATUM);
+	canvas[canvasid].drawString(String(settings.config.compass.hard_iron[2], 0), display.width *.75, 250);
+}
+
+/**
+ * 
+ */
+void AppCompass::drawCompass(int x, int y, float angle)
+{
 	// TFT_TRANSPARENT is a special colour with reversible 8/16 bit coding
 	// this allows it to be used in both 8 and 16 bit colour sprites.
 	canvas[canvasid].fillSprite(TFT_TRANSPARENT);
 
-#define NEEDLE_L 84 / 2 // Needle length is 84, we want radius which is 42
-#define NEEDLE_W 12 / 2 // Needle width is 12, radius is then 6
-
-	// Draw the old needle position in the screen background colour so
-	// it gets erased on the TFT when the sprite is drawn
-	canvas[canvasid].fillTriangle(lx1, ly1, lx3, ly3, lx4, ly4, BACKGROUND);
-	canvas[canvasid].fillTriangle(lx2, ly2, lx3, ly3, lx4, ly4, BACKGROUND);
-
-	// Set text coordinate datum to middle centre
-	canvas[canvasid].setTextDatum(MC_DATUM);
-	canvas[canvasid].setTextColor(TFT_WHITE);
-
-	canvas[canvasid].drawString("N", 120, 140 - 42);
-	canvas[canvasid].drawString("E", 120 + 42, 140);
-	canvas[canvasid].drawString("S", 120, 140 + 42);
-	canvas[canvasid].drawString("W", 120 - 42, 140);
-
 	canvas[canvasid].drawCircle(120, 140, 30, TFT_DARKGREY);
 
-	getCoord(x, y, &lx1, &ly1, NEEDLE_L, angle);
-	getCoord(x, y, &lx2, &ly2, NEEDLE_L, angle + 180);
-	getCoord(x, y, &lx3, &ly3, NEEDLE_W, angle + 90);
-	getCoord(x, y, &lx4, &ly4, NEEDLE_W, angle - 90);
+	/*
+	 Rotate a unit 1 vector pointing down (Cartesian coordinate) [x: 0, y: 1] around the origin at given angle
+	 we can reduce the calcs in the rotation matrix due to the x component being 0 and y being 1
+	 
+	 xp = x * cos(a) - y * sin(a)
+	 yp = y * cos(a) + x * sin(a)
+	 
+	 this recuces down to
+	 
+	 xp = -y * sin(a)
+	 yp =  y * cos(a)
+	 
+	 the result is a normalized vector that can then be multiplied by a radius, using left hand rule
+	*/
+	
+	// we can multiply these normals with a radius to get all the coords we need
+	float normal_x, normal_y, normal_x_90, normal_y_90;
+	float angle_rad = angle * DEG_TO_RAD;
+	
+	// get the rotated up normalised vector
+	normal_x = -sin(angle_rad);
+	normal_y =  cos(angle_rad);
 
-	canvas[canvasid].fillTriangle(lx1, ly1, lx3, ly3, lx4, ly4, TFT_RED);
-	canvas[canvasid].fillTriangle(lx2, ly2, lx3, ly3, lx4, ly4, TFT_LIGHTGREY);
+	// trick that rotates the normal 90 deg for E and W
+	normal_x_90 = -normal_y;
+	normal_y_90 =  normal_x;
 
-	canvas[canvasid].fillCircle(120, 140, 3, TFT_DARKGREY);
-	canvas[canvasid].fillCircle(120, 140, 2, TFT_LIGHTGREY);
+	text_N_x = x - NESW_RADIUS * normal_x;
+	text_N_y = y - NESW_RADIUS * normal_y;
+	text_S_x = x + NESW_RADIUS * normal_x;
+	text_S_y = y + NESW_RADIUS * normal_y;
+
+	text_E_x = x - NESW_RADIUS * normal_x_90 * 0.6;
+	text_E_y = y - NESW_RADIUS * normal_y_90 * 0.6;	
+	text_W_x = x + NESW_RADIUS * normal_x_90 * 0.6;
+	text_W_y = y + NESW_RADIUS * normal_y_90 * 0.6;
+
+	canvas[canvasid].setFreeFont(RobotoMono_Regular[12]);
+	canvas[canvasid].setTextColor(TFT_RED);
+	canvas[canvasid].setTextDatum(CC_DATUM);
+	canvas[canvasid].drawString("N", text_N_x, text_N_y);
+	canvas[canvasid].setTextColor(TFT_WHITE);
+	canvas[canvasid].drawString("E", text_E_x, text_E_y);
+	canvas[canvasid].drawString("S", text_S_x, text_S_y);
+	canvas[canvasid].drawString("W", text_W_x, text_W_y);
+	canvas[canvasid].setTextColor(TFT_ORANGE);
+	canvas[canvasid].drawString(String(angle, 2), display.width / 2, 240);
+
+	needle_N_x = x - NEEDLE_L * normal_x;
+	needle_N_y = y - NEEDLE_L * normal_y;
+	needle_S_x = x + NEEDLE_L * normal_x;
+	needle_S_y = y + NEEDLE_L * normal_y;
+
+	needle_E_x = x - NEEDLE_W * normal_x_90;
+	needle_E_y = y - NEEDLE_W * normal_y_90;
+	needle_W_x = x + NEEDLE_W * normal_x_90;
+	needle_W_y = y + NEEDLE_W * normal_y_90;
+
+	canvas[canvasid].fillTriangle(needle_N_x, needle_N_y, needle_E_x, needle_E_y, needle_W_x, needle_W_y, TFT_RED);
+	canvas[canvasid].fillTriangle(needle_S_x, needle_S_y, needle_E_x, needle_E_y, needle_W_x, needle_W_y, TFT_LIGHTGREY);
+
+	canvas[canvasid].fillSmoothCircle(120, 140, 3, TFT_DARKGREY, TFT_LIGHTGREY);
 }
-
-// Get coordinates of end of a vector, centre at x,y, length r, angle a
-// Coordinates are returned to caller via the xp and yp pointers
-void AppCompass::getCoord(int x, int y, int *xp, int *yp, int r, int a)
-{
-	float sx1 = cos((a - 90) * RAD2DEG);
-	float sy1 = sin((a - 90) * RAD2DEG);
-	*xp = sx1 * r + x;
-	*yp = sy1 * r + y;
-}
-
-bool AppCompass::process_touch(touch_event_t touch_event) { return false; }
 
 AppCompass app_compass;

--- a/Platform-io-source/src/tw_apps/app_Compass.cpp
+++ b/Platform-io-source/src/tw_apps/app_Compass.cpp
@@ -363,7 +363,7 @@ void AppCompass::drawCompass()
 	canvas[canvasid].drawString("W", text_W_x, text_W_y);
 	canvas[canvasid].setTextColor(TFT_ORANGE);
 	uint8_t l = canvas[canvasid].drawString(String(heading, 0), display.center_x, 240);
-	canvas[canvasid].drawSmoothCircle(display.center_x + l - 8, 236, 3, TFT_ORANGE, TFT_BLACK);
+	canvas[canvasid].drawSmoothCircle(display.center_x + l * .5 + 7, 236, 3, TFT_ORANGE, TFT_BLACK);
 
 	uint8_t needle_N_x = display.center_x - NEEDLE_L * normal_x;
 	uint8_t needle_N_y = display.center_y - NEEDLE_L * normal_y;

--- a/Platform-io-source/src/tw_apps/app_Compass.cpp
+++ b/Platform-io-source/src/tw_apps/app_Compass.cpp
@@ -105,13 +105,11 @@ void AppCompass::draw(bool force)
 		setup();
 		next_update = millis();
 
-		heading = moveTowardsHeading(heading, imu.get_yaw());
-
 		switch(running_state)
 		{
 			case RUNNING_STATE_DRAW:
 			{
-				drawCompass(120, 140, heading); // Draw centre of compass at 120,140
+				drawCompass(); // Draw centre of compass at 120,140
 				break;
 			}
 
@@ -124,32 +122,6 @@ void AppCompass::draw(bool force)
 
 		canvas[canvasid].pushSprite(_x, _y);
 	}
-}
-
-/**
- * 	@brief Move one heading towards another (0.0 > 360.0)
- */
-float AppCompass::moveTowardsHeading(float currentHeading, float newHeading)
-{
-	newHeading = newHeading;
-
-	float result;
-	float a = newHeading - currentHeading;
-	float b = newHeading < currentHeading
-		? newHeading + 360.0 - currentHeading 
-		: newHeading - 360.0 - currentHeading
-	;
-	result = abs(a) < abs(b)
-		? currentHeading + a
-		: currentHeading + b
-	;
-
-	if (result >= 360.0)
-		result -= 360.0;
-	if (result < 0.0)
-		result += 360.0;
-
-	return result;
 }
 
 /**
@@ -184,7 +156,7 @@ void AppCompass::drawCalibrate()
 	float mag_y;
 	float mag_z;
 
-	imu.get_magnetic(&mag_x, &mag_y, &mag_z);
+	imu.get_magnetic(&mag_x, &mag_y, &mag_z, false);
 
 	mag_x_min = min(mag_x, mag_x_min);
 	mag_y_min = min(mag_y, mag_y_min);
@@ -213,47 +185,52 @@ void AppCompass::drawCalibrate()
 	
 	canvas[canvasid].setTextColor(TFT_WHITE);
 	canvas[canvasid].setTextDatum(CC_DATUM);
-	canvas[canvasid].drawString("Calibrating", display.width / 2, 10);
+	canvas[canvasid].drawString("Calibrating", display.width / 2, 10);		
 		
-		
-	float right1 = display.width -  20;
+	float right1 = display.width - 180;
 	float right2 = display.width - 100;
-	float right3 = display.width - 180;
+	float right3 = display.width -  20;
 	float top = 20;
 		
 	canvas[canvasid].setTextDatum(CR_DATUM);
 
 	canvas[canvasid].setTextColor(TFT_WHITE);
-	top += 30;	
+	top += 30;
+	// current hard iron settings
 	canvas[canvasid].drawString(String(settings.config.compass.hard_iron_x, 1), right1, top);
 	canvas[canvasid].drawString(String(settings.config.compass.hard_iron_y, 1), right2, top);
 	canvas[canvasid].drawString(String(settings.config.compass.hard_iron_z, 1), right3, top);
 	
 	canvas[canvasid].setTextColor(TFT_GREEN);
 	top += 30;
+	// new hard iron settings
 	canvas[canvasid].drawString(String(hard_iron_x, 1), right1, top);
 	canvas[canvasid].drawString(String(hard_iron_y, 1), right2, top);
 	canvas[canvasid].drawString(String(hard_iron_z, 1), right3, top);	
 
 	canvas[canvasid].setTextColor(TFT_ORANGE);
 	top += 30;
-	canvas[canvasid].drawString(String(mag_x_max, 1), right1, top);
-	canvas[canvasid].drawString(String(mag_y_max, 1), right2, top);
-	canvas[canvasid].drawString(String(mag_z_max, 1), right3, top);
-
-	top += 30;
+	// magnetic min values
 	canvas[canvasid].drawString(String(mag_x_min, 1), right1, top);
 	canvas[canvasid].drawString(String(mag_y_min, 1), right2, top);
 	canvas[canvasid].drawString(String(mag_z_min, 1), right3, top);
+
+	top += 30;
+	// magnetic max values
+	canvas[canvasid].drawString(String(mag_x_max, 1), right1, top);
+	canvas[canvasid].drawString(String(mag_y_max, 1), right2, top);
+	canvas[canvasid].drawString(String(mag_z_max, 1), right3, top);
 	
 	canvas[canvasid].setTextColor(TFT_WHITE);
 	top += 30;
+	// current soft iron settings
 	canvas[canvasid].drawString(String(settings.config.compass.soft_iron_x, 2), right1, top);
 	canvas[canvasid].drawString(String(settings.config.compass.soft_iron_y, 2), right2, top);
 	canvas[canvasid].drawString(String(settings.config.compass.soft_iron_z, 2), right3, top);
 	
 	canvas[canvasid].setTextColor(TFT_GREEN);
 	top += 30;
+	// new soft iron settings
 	canvas[canvasid].drawString(String(soft_iron_x, 2), right1, top);
 	canvas[canvasid].drawString(String(soft_iron_y, 2), right2, top);
 	canvas[canvasid].drawString(String(soft_iron_z, 2), right3, top);
@@ -266,8 +243,25 @@ void AppCompass::drawCalibrate()
 /**
  * 
  */
-void AppCompass::drawCompass(int x, int y, float angle)
+void AppCompass::drawCompass()
 {
+	float newHeading = imu.get_yaw();
+
+	float a = newHeading - heading;
+	float b = newHeading < heading
+		? newHeading + 360.0 - heading 
+		: newHeading - 360.0 - heading
+	;
+	heading = abs(a) < abs(b)
+		? heading + a
+		: heading + b
+	;
+
+	if (heading >= 360.0)
+		heading -= 360.0;
+	if (heading < 0.0)
+		heading += 360.0;
+
 	// TFT_TRANSPARENT is a special colour with reversible 8/16 bit coding
 	// this allows it to be used in both 8 and 16 bit colour sprites.
 	canvas[canvasid].fillSprite(TFT_TRANSPARENT);
@@ -295,25 +289,25 @@ void AppCompass::drawCompass(int x, int y, float angle)
 	
 	// we can multiply these normals with a radius to get all the coords we need
 	float normal_x, normal_y, normal_x_90, normal_y_90;
-	float angle_rad = angle * DEG_TO_RAD;
+	float heading_in_rad = heading * DEG_TO_RAD;
 	
 	// get the rotated up normalised vector
-	normal_x = -sin(angle_rad);
-	normal_y =  cos(angle_rad);
+	normal_x = -sin(heading_in_rad);
+	normal_y =  cos(heading_in_rad);
 
 	// trick that rotates the normal 90 deg for E and W
 	normal_x_90 = -normal_y;
 	normal_y_90 =  normal_x;
 
-	text_N_x = x - NESW_RADIUS * normal_x;
-	text_N_y = y - NESW_RADIUS * normal_y;
-	text_S_x = x + NESW_RADIUS * normal_x;
-	text_S_y = y + NESW_RADIUS * normal_y;
+	text_N_x = display.center_x - NESW_RADIUS * normal_x;
+	text_N_y = display.center_y - NESW_RADIUS * normal_y;
+	text_S_x = display.center_x + NESW_RADIUS * normal_x;
+	text_S_y = display.center_y + NESW_RADIUS * normal_y;
 
-	text_E_x = x - NESW_RADIUS * normal_x_90 * 0.6;
-	text_E_y = y - NESW_RADIUS * normal_y_90 * 0.6;	
-	text_W_x = x + NESW_RADIUS * normal_x_90 * 0.6;
-	text_W_y = y + NESW_RADIUS * normal_y_90 * 0.6;
+	text_E_x = display.center_x - NESW_RADIUS * normal_x_90 * 0.6;
+	text_E_y = display.center_y - NESW_RADIUS * normal_y_90 * 0.6;	
+	text_W_x = display.center_x + NESW_RADIUS * normal_x_90 * 0.6;
+	text_W_y = display.center_y + NESW_RADIUS * normal_y_90 * 0.6;
 
 	canvas[canvasid].setFreeFont(RobotoMono_Regular[12]);
 	canvas[canvasid].setTextColor(TFT_RED);
@@ -324,17 +318,17 @@ void AppCompass::drawCompass(int x, int y, float angle)
 	canvas[canvasid].drawString("S", text_S_x, text_S_y);
 	canvas[canvasid].drawString("W", text_W_x, text_W_y);
 	canvas[canvasid].setTextColor(TFT_ORANGE);
-	canvas[canvasid].drawString(String(angle, 2), display.width / 2, 240);
+	canvas[canvasid].drawString(String(heading, 2), display.width / 2, 240);
 
-	needle_N_x = x - NEEDLE_L * normal_x;
-	needle_N_y = y - NEEDLE_L * normal_y;
-	needle_S_x = x + NEEDLE_L * normal_x;
-	needle_S_y = y + NEEDLE_L * normal_y;
+	needle_N_x = display.center_x - NEEDLE_L * normal_x;
+	needle_N_y = display.center_y - NEEDLE_L * normal_y;
+	needle_S_x = display.center_x + NEEDLE_L * normal_x;
+	needle_S_y = display.center_y + NEEDLE_L * normal_y;
 
-	needle_E_x = x - NEEDLE_W * normal_x_90;
-	needle_E_y = y - NEEDLE_W * normal_y_90;
-	needle_W_x = x + NEEDLE_W * normal_x_90;
-	needle_W_y = y + NEEDLE_W * normal_y_90;
+	needle_E_x = display.center_x - NEEDLE_W * normal_x_90;
+	needle_E_y = display.center_y - NEEDLE_W * normal_y_90;
+	needle_W_x = display.center_x + NEEDLE_W * normal_x_90;
+	needle_W_y = display.center_y + NEEDLE_W * normal_y_90;
 
 	canvas[canvasid].fillTriangle(needle_N_x, needle_N_y, needle_E_x, needle_E_y, needle_W_x, needle_W_y, TFT_RED);
 	canvas[canvasid].fillTriangle(needle_S_x, needle_S_y, needle_E_x, needle_E_y, needle_W_x, needle_W_y, TFT_LIGHTGREY);

--- a/Platform-io-source/src/tw_apps/app_Compass.cpp
+++ b/Platform-io-source/src/tw_apps/app_Compass.cpp
@@ -71,9 +71,9 @@ bool AppCompass::process_touch(touch_event_t touch_event)
 		}
 		else if (running_state == RUNNING_STATE_CALIBRATE && touch_event.dir == TOUCH_SWIPE_UP)
 		{
-			settings.config.compass.hard_iron[0] = hard_iron_avg[0];
-			settings.config.compass.hard_iron[1] = hard_iron_avg[1];
-			settings.config.compass.hard_iron[2] = hard_iron_avg[2];
+			settings.config.compass.hard_iron_x = hard_iron_avg[0];
+			settings.config.compass.hard_iron_y = hard_iron_avg[1];
+			settings.config.compass.hard_iron_z = hard_iron_avg[2];
 			settings.save(true);
 			info_print(F("Compass hard iron values saved"));			
 			running_state = RUNNING_STATE_DRAW;
@@ -214,19 +214,23 @@ void AppCompass::drawCalibrate()
 	canvas[canvasid].setTextDatum(CL_DATUM);
 	canvas[canvasid].drawString("X:", display.width *.25, 210);
 	canvas[canvasid].setTextDatum(CR_DATUM);
-	canvas[canvasid].drawString(String(settings.config.compass.hard_iron[0], 0), display.width *.75, 210);
+	canvas[canvasid].drawString(String(settings.config.compass.hard_iron_x, 0), display.width *.75, 210);
 
 	canvas[canvasid].setTextColor(TFT_ORANGE);
 	canvas[canvasid].setTextDatum(CL_DATUM);
 	canvas[canvasid].drawString("X:", display.width *.25, 230);
 	canvas[canvasid].setTextDatum(CR_DATUM);
-	canvas[canvasid].drawString(String(settings.config.compass.hard_iron[1], 0), display.width *.75, 230);
+	canvas[canvasid].drawString(String(settings.config.compass.hard_iron_y, 0), display.width *.75, 230);
 
 	canvas[canvasid].setTextColor(TFT_ORANGE);
 	canvas[canvasid].setTextDatum(CL_DATUM);
 	canvas[canvasid].drawString("X:", display.width *.25, 250);
 	canvas[canvasid].setTextDatum(CR_DATUM);
-	canvas[canvasid].drawString(String(settings.config.compass.hard_iron[2], 0), display.width *.75, 250);
+	canvas[canvasid].drawString(String(settings.config.compass.hard_iron_z, 0), display.width *.75, 250);
+		
+	canvas[canvasid].setTextColor(TFT_WHITE);
+	canvas[canvasid].setTextDatum(CL_DATUM);
+	canvas[canvasid].drawString("/\\", 0, 260);
 }
 
 /**
@@ -237,6 +241,10 @@ void AppCompass::drawCompass(int x, int y, float angle)
 	// TFT_TRANSPARENT is a special colour with reversible 8/16 bit coding
 	// this allows it to be used in both 8 and 16 bit colour sprites.
 	canvas[canvasid].fillSprite(TFT_TRANSPARENT);
+
+	canvas[canvasid].setTextColor(TFT_WHITE);
+	canvas[canvasid].setTextDatum(CL_DATUM);
+	canvas[canvasid].drawString("\\/", 0, 20);
 
 	canvas[canvasid].drawCircle(120, 140, 30, TFT_DARKGREY);
 

--- a/Platform-io-source/src/tw_apps/app_Compass.h
+++ b/Platform-io-source/src/tw_apps/app_Compass.h
@@ -44,8 +44,7 @@ class AppCompass : public tw_app
 		uint8_t text_W_x = 0;
 		uint8_t text_W_y = 0;
 
-		float moveTowardsHeading(float currentHeading, float newHeading);
-		void drawCompass(int x, int y, float angle);
+		void drawCompass();
 		void drawCalibrate();
 		void resetCalibration();
 

--- a/Platform-io-source/src/tw_apps/app_Compass.h
+++ b/Platform-io-source/src/tw_apps/app_Compass.h
@@ -24,7 +24,6 @@ class AppCompass : public tw_app
 		#define RUNNING_STATE_CALIBRATE 2
 		
 		float heading = 0;
-		float align_rate = 0.66; // rate at which the needle follows the imu
 		uint8_t running_state;
 
 		uint8_t needle_N_x = 0;
@@ -50,10 +49,23 @@ class AppCompass : public tw_app
 		void drawCalibrate();
 		void resetCalibration();
 
-		// hard iron calibration
-		float hard_iron_avg[3];
-		float hard_iron_min[3];
-		float hard_iron_max[3];
+		//these are needed for calibration
+
+		float mag_x_min;
+		float mag_y_min;
+		float mag_z_min;
+
+		float mag_x_max;
+		float mag_y_max;
+		float mag_z_max;
+		
+		float hard_iron_x;
+		float hard_iron_y;
+		float hard_iron_z;
+
+		float soft_iron_x;
+		float soft_iron_y;
+		float soft_iron_z;
 };
 
 extern AppCompass app_compass;

--- a/Platform-io-source/src/tw_apps/app_Compass.h
+++ b/Platform-io-source/src/tw_apps/app_Compass.h
@@ -23,9 +23,14 @@ class AppCompass : public tw_app
 		#define RUNNING_STATE_DRAW 1
 		#define RUNNING_STATE_CALIBRATE 2
 		
+		#define B_BLUE RGB(10, 40, 60)
+		#define B_RED RGB(40, 20, 20)
+		#define B_GREEN RGB(20, 40, 20)
+
 		float heading = 0;
 		uint8_t running_state;
 
+		void drawUI();
 		void drawCompass();
 		void drawCalibrate();
 		void resetCalibration();

--- a/Platform-io-source/src/tw_apps/app_Compass.h
+++ b/Platform-io-source/src/tw_apps/app_Compass.h
@@ -11,28 +11,49 @@ class AppCompass : public tw_app
 		void draw_icon(uint8_t canvasid, int16_t _pos_x, int16_t _pos_y, uint8_t style_hint);
 		bool process_touch(touch_event_t touch_event);
 
-		void drawCompass(int x, int y, int angle);
-		void getCoord(int x, int y, int *xp, int *yp, int r, int a);
-
 	private:
-		String version = "1.0";
-		bool showingGyro = false;
+		#define BACKGROUND TFT_BLACK
+		
+		// needle values
+		#define NEEDLE_L 84 / 2 // Needle length is 84, we want radius which is 42
+		#define NEEDLE_W 12 / 2 // Needle width is 12, radius is then 6
+		#define NESW_RADIUS 60 // radius that N E S W rotate around	
+			
+		// running states
+		#define RUNNING_STATE_DRAW 1
+		#define RUNNING_STATE_CALIBRATE 2
+		
+		float heading = 0;
+		float align_rate = 0.66; // rate at which the needle follows the imu
+		uint8_t running_state;
 
-		int number = 0;
-		int angle = 0;
+		uint8_t needle_N_x = 0;
+		uint8_t needle_N_y = 0;
+		uint8_t needle_E_x = 0;
+		uint8_t needle_E_y = 0;
+		uint8_t needle_S_x = 0;
+		uint8_t needle_S_y = 0;
+		uint8_t needle_W_x = 0;
+		uint8_t needle_W_y = 0;
 
-		int lx1 = 0;
-		int ly1 = 0;
-		int lx2 = 0;
-		int ly2 = 0;
-		int lx3 = 0;
-		int ly3 = 0;
-		int lx4 = 0;
-		int ly4 = 0;
+		uint8_t text_N_x = 0;
+		uint8_t text_N_y = 0;
+		uint8_t text_E_x = 0;
+		uint8_t text_E_y = 0;
+		uint8_t text_S_x = 0;
+		uint8_t text_S_y = 0;
+		uint8_t text_W_x = 0;
+		uint8_t text_W_y = 0;
 
-		// Test only
-		uint16_t n = 0;
-		uint32_t dt = 0;
+		float moveTowardsHeading(float currentHeading, float newHeading);
+		void drawCompass(int x, int y, float angle);
+		void drawCalibrate();
+		void resetCalibration();
+
+		// hard iron calibration
+		float hard_iron_avg[3];
+		float hard_iron_min[3];
+		float hard_iron_max[3];
 };
 
 extern AppCompass app_compass;

--- a/Platform-io-source/src/tw_apps/app_Compass.h
+++ b/Platform-io-source/src/tw_apps/app_Compass.h
@@ -26,24 +26,6 @@ class AppCompass : public tw_app
 		float heading = 0;
 		uint8_t running_state;
 
-		uint8_t needle_N_x = 0;
-		uint8_t needle_N_y = 0;
-		uint8_t needle_E_x = 0;
-		uint8_t needle_E_y = 0;
-		uint8_t needle_S_x = 0;
-		uint8_t needle_S_y = 0;
-		uint8_t needle_W_x = 0;
-		uint8_t needle_W_y = 0;
-
-		uint8_t text_N_x = 0;
-		uint8_t text_N_y = 0;
-		uint8_t text_E_x = 0;
-		uint8_t text_E_y = 0;
-		uint8_t text_S_x = 0;
-		uint8_t text_S_y = 0;
-		uint8_t text_W_x = 0;
-		uint8_t text_W_y = 0;
-
 		void drawCompass();
 		void drawCalibrate();
 		void resetCalibration();
@@ -57,14 +39,6 @@ class AppCompass : public tw_app
 		float mag_x_max;
 		float mag_y_max;
 		float mag_z_max;
-		
-		float hard_iron_x;
-		float hard_iron_y;
-		float hard_iron_z;
-
-		float soft_iron_x;
-		float soft_iron_y;
-		float soft_iron_z;
 };
 
 extern AppCompass app_compass;


### PR DESCRIPTION
This modifies the core IMU class to enable functionality for in-watch hard iron calibration, including a more basic, but hopefully adequate soft iron calibration method.   The calibration can be stored in flash and is currently done via the compass app.

The tilt compensation is integreated into the get_yaw() method, and has an input parameter that lets you skip the tilt compensation result.
There is a new method called get_magnetic() that expects three float pointers for x, y and z magnetic reading, including a bool that lets you skip hard and soft iron calibration.

The compass app has been modified to perform fewer sin cos calulations, and has some basic UI to facilitate performing and storing magnetometer calibration.